### PR TITLE
Add list_job_builds and get_build_info tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ semantic_search "authentication timeout build"
 # Ranked by relevance, not just keyword matching
 ```
 
-## 🔧 **Available Tools** (12 Total)
+## 🔧 **Available Tools** (11–12 depending on vector search)
 
 ### 🤖 **AI & Diagnostic Tools**
 | Tool | Purpose | Unique Features |

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ semantic_search "authentication timeout build"
 # Ranked by relevance, not just keyword matching
 ```
 
-## 🔧 **Available Tools** (10 Total)
+## 🔧 **Available Tools** (12 Total)
 
 ### 🤖 **AI & Diagnostic Tools**
 | Tool | Purpose | Unique Features |
@@ -289,6 +289,8 @@ semantic_search "authentication timeout build"
 | `trigger_build_async` | **Asynchronous build triggering** | Non-blocking execution, parallel builds |
 | `trigger_build_with_subs` | **Sub-build monitoring** | Real-time status tracking, hierarchy discovery |
 | `get_jenkins_job_parameters` | **Job parameter discovery** | Multi-instance support, parameter details |
+| `list_job_builds` | **Enumerate recent builds** | Tree-filter metadata (number, result, timestamp, duration, description) for build selection |
+| `get_build_info` | **Single build metadata** | Supports explicit build numbers and `lastBuild` with optional `depth`/`tree` |
 
 ### 🔍 **Log Analysis & Search Tools**
 | Tool | Purpose | Unique Features |

--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ semantic_search "authentication timeout build"
 | Tool | Purpose | Unique Features |
 |------|---------|-----------------|
 | `diagnose_build_failure` | **AI failure analysis** | Sub-build hierarchy, semantic search, custom recommendations |
-| `semantic_search` | **Vector-powered search** | Cross-build pattern recognition, relevance ranking |
+| `semantic_search` | **Vector-powered search** *(requires vector search enabled)* | Cross-build pattern recognition, relevance ranking |
 
 ### 🚀 **Build Management Tools**
 | Tool | Purpose | Unique Features |

--- a/jenkins_mcp_enterprise/tool_factory.py
+++ b/jenkins_mcp_enterprise/tool_factory.py
@@ -15,6 +15,7 @@ from typing import Dict
 
 from .base import Tool
 from .di_container import DIContainer
+from .tools.builds import GetBuildInfoTool, ListJobBuildsTool
 from .tools.diagnostics import DiagnoseBuildFailureTool
 from .tools.jenkins_tools import GetJobParametersTool
 from .tools.logs import FilterErrorsTool, LogContextTool
@@ -76,6 +77,16 @@ class ToolFactory:
             jenkins_client=jenkins_client, multi_jenkins_manager=multi_jenkins_manager
         )
         tools[get_params_tool.name] = get_params_tool
+
+        list_builds_tool = ListJobBuildsTool(
+            jenkins_client=jenkins_client, multi_jenkins_manager=multi_jenkins_manager
+        )
+        tools[list_builds_tool.name] = list_builds_tool
+
+        get_build_info_tool = GetBuildInfoTool(
+            jenkins_client=jenkins_client, multi_jenkins_manager=multi_jenkins_manager
+        )
+        tools[get_build_info_tool.name] = get_build_info_tool
 
         # Tools requiring JenkinsClient and CacheManager (now with multi-instance support)
         async_tool = AsyncBuildTool(
@@ -174,7 +185,7 @@ class ToolFactory:
             The number of tools this factory creates
         """
         # Base tools count (without vector search tools)
-        base_count = 9
+        base_count = 11
 
         # Add vector search tools if enabled
         vector_manager = self.container.get_vector_manager()

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -253,7 +253,7 @@ class GetBuildInfoTool(JenkinsOperationTool):
                 return {
                     "job_name": normalized_job,
                     "jenkins_url": jenkins_url,
-                    "build_number": build_number,
+                    "requested_build_number": build_number,
                     "api_url": api_url,
                     "error": (
                         "Build not found (HTTP 404). The job may not exist, "
@@ -267,7 +267,7 @@ class GetBuildInfoTool(JenkinsOperationTool):
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "build_number": build_number,
+                "requested_build_number": build_number,
                 "api_url": api_url,
                 "error": f"Jenkins API request failed: {str(e)}",
             }
@@ -275,7 +275,7 @@ class GetBuildInfoTool(JenkinsOperationTool):
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "build_number": build_number,
+                "requested_build_number": build_number,
                 "api_url": api_url,
                 "error": f"Invalid JSON response from Jenkins: {str(e)}",
             }

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -45,7 +45,7 @@ class ListJobBuildsTool(JenkinsOperationTool):
 
     def __init__(
         self,
-        jenkins_client: Optional[JenkinsClient] = None,
+        jenkins_client: JenkinsClient,
         multi_jenkins_manager=None,
     ):
         super().__init__(
@@ -60,11 +60,13 @@ class ListJobBuildsTool(JenkinsOperationTool):
     @property
     def description(self) -> str:
         return (
-            "📋 LIST BUILDS: Returns recent builds for a Jenkins job with metadata "
+            "Returns recent builds for a Jenkins job with metadata "
             "(number, result, timestamp, duration, description, displayName, url), "
             "so callers can pick a specific build by criteria before calling "
-            "log-analysis tools. IMPORTANT: jenkins_url is required because jobs "
-            "are load-balanced across multiple Jenkins servers."
+            "log-analysis tools. Queries a single Jenkins instance per call "
+            "(resolved from `jenkins_url`); does not aggregate across configured "
+            "instances. IMPORTANT: jenkins_url is required because jobs are "
+            "load-balanced across multiple Jenkins servers."
         )
 
     @property
@@ -173,7 +175,7 @@ class GetBuildInfoTool(JenkinsOperationTool):
 
     def __init__(
         self,
-        jenkins_client: Optional[JenkinsClient] = None,
+        jenkins_client: JenkinsClient,
         multi_jenkins_manager=None,
     ):
         super().__init__(
@@ -188,9 +190,11 @@ class GetBuildInfoTool(JenkinsOperationTool):
     @property
     def description(self) -> str:
         return (
-            "ℹ️ BUILD INFO: Returns metadata for a single Jenkins build (number, "
-            "result, timestamp, duration, description, parameters, url, ...). "
-            "When build_number is omitted, the job's 'lastBuild' is returned. "
+            "Returns metadata for a single Jenkins build (number, result, "
+            "timestamp, duration, description, parameters, url, ...). When "
+            "build_number is omitted, the job's 'lastBuild' is returned. "
+            "Queries a single Jenkins instance per call (resolved from "
+            "`jenkins_url`); does not aggregate across configured instances. "
             "IMPORTANT: jenkins_url is required because jobs are load-balanced "
             "across multiple Jenkins servers."
         )

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -34,10 +34,10 @@ def _clamp_count(value: int) -> int:
     """Clamp ``count`` to ``[MIN_LIST_COUNT, MAX_LIST_COUNT]``.
 
     ``ParameterSpec("count", int, ..., default=DEFAULT_LIST_COUNT)`` at the
-    tool boundary guarantees numeric input and supplies the default when the
-    parameter is omitted, so this helper only has to enforce the range.
+    tool boundary coerces numeric strings to ``int`` and supplies the default
+    when the parameter is omitted, so this helper only has to enforce range.
     """
-    return max(MIN_LIST_COUNT, min(int(value), MAX_LIST_COUNT))
+    return max(MIN_LIST_COUNT, min(value, MAX_LIST_COUNT))
 
 
 class ListJobBuildsTool(JenkinsOperationTool):
@@ -99,7 +99,7 @@ class ListJobBuildsTool(JenkinsOperationTool):
     def _execute_impl(self, **kwargs) -> Dict[str, Any]:
         job_name = kwargs["job_name"]
         jenkins_url = kwargs["jenkins_url"]
-        count = _clamp_count(kwargs.get("count"))
+        effective_count = _clamp_count(kwargs.get("count"))
         tree_override = (kwargs.get("tree") or "").strip()
 
         try:
@@ -113,11 +113,14 @@ class ListJobBuildsTool(JenkinsOperationTool):
                 "instructions": self.get_instance_instructions(),
             }
 
+        # to_jenkins_api_path() normalizes internally; pass raw input and
+        # keep a single explicit normalize_job_name() call for the
+        # response's canonical echo.
         normalized_job = JobNameParser.normalize_job_name(job_name)
-        api_job_path = JobNameParser.to_jenkins_api_path(normalized_job)
+        api_job_path = JobNameParser.to_jenkins_api_path(job_name)
         base_url = jenkins_client.config.url.rstrip("/")
         base_tree = tree_override if tree_override else DEFAULT_LIST_TREE
-        tree_value = f"{base_tree}{{0,{count}}}"
+        tree_value = f"{base_tree}{{0,{effective_count}}}"
         api_url = f"{base_url}/{api_job_path}/api/json"
 
         try:
@@ -158,7 +161,8 @@ class ListJobBuildsTool(JenkinsOperationTool):
             "job_name": normalized_job,
             "jenkins_url": jenkins_url,
             "tree": tree_value,
-            "count": len(builds),
+            "requested_count": effective_count,
+            "returned_count": len(builds),
             "builds": builds,
         }
 
@@ -243,8 +247,11 @@ class GetBuildInfoTool(JenkinsOperationTool):
                 "instructions": self.get_instance_instructions(),
             }
 
+        # to_jenkins_api_path() normalizes internally; pass raw input and
+        # keep a single explicit normalize_job_name() call for the
+        # response's canonical echo.
         normalized_job = JobNameParser.normalize_job_name(job_name)
-        api_job_path = JobNameParser.to_jenkins_api_path(normalized_job)
+        api_job_path = JobNameParser.to_jenkins_api_path(job_name)
         base_url = jenkins_client.config.url.rstrip("/")
         build_segment = str(build_number) if build_number is not None else "lastBuild"
         api_url = f"{base_url}/{api_job_path}/{build_segment}/api/json"

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -30,19 +30,24 @@ MAX_LIST_COUNT = 500
 MIN_LIST_COUNT = 1
 
 
-def _clamp_count(value: Any) -> int:
-    """Coerce ``count`` to a safe int within ``[MIN_LIST_COUNT, MAX_LIST_COUNT]``."""
-    try:
-        n = int(value) if value is not None else DEFAULT_LIST_COUNT
-    except (TypeError, ValueError):
-        n = DEFAULT_LIST_COUNT
-    return max(MIN_LIST_COUNT, min(n, MAX_LIST_COUNT))
+def _clamp_count(value: int) -> int:
+    """Clamp ``count`` to ``[MIN_LIST_COUNT, MAX_LIST_COUNT]``.
+
+    ``ParameterSpec("count", int, ..., default=DEFAULT_LIST_COUNT)`` at the
+    tool boundary guarantees numeric input and supplies the default when the
+    parameter is omitted, so this helper only has to enforce the range.
+    """
+    return max(MIN_LIST_COUNT, min(int(value), MAX_LIST_COUNT))
 
 
 class ListJobBuildsTool(JenkinsOperationTool):
     """Lists recent builds of a Jenkins job with metadata for filtering."""
 
-    def __init__(self, jenkins_client: JenkinsClient, multi_jenkins_manager=None):
+    def __init__(
+        self,
+        jenkins_client: Optional[JenkinsClient] = None,
+        multi_jenkins_manager=None,
+    ):
         super().__init__(
             jenkins_client=jenkins_client,
             multi_jenkins_manager=multi_jenkins_manager,
@@ -161,7 +166,11 @@ class ListJobBuildsTool(JenkinsOperationTool):
 class GetBuildInfoTool(JenkinsOperationTool):
     """Fetches metadata for a single Jenkins build (or ``lastBuild``)."""
 
-    def __init__(self, jenkins_client: JenkinsClient, multi_jenkins_manager=None):
+    def __init__(
+        self,
+        jenkins_client: Optional[JenkinsClient] = None,
+        multi_jenkins_manager=None,
+    ):
         super().__init__(
             jenkins_client=jenkins_client,
             multi_jenkins_manager=multi_jenkins_manager,

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -102,21 +102,22 @@ class ListJobBuildsTool(JenkinsOperationTool):
         effective_count = _clamp_count(kwargs.get("count"))
         tree_override = (kwargs.get("tree") or "").strip()
 
+        # Compute the canonical echo up-front so every return path shows the
+        # same job_name value. to_jenkins_api_path() normalizes internally,
+        # so pass raw input there and reuse normalized_job only in responses.
+        normalized_job = JobNameParser.normalize_job_name(job_name)
+
         try:
             instance_id = self.resolve_jenkins_instance(jenkins_url)
             jenkins_client = self.get_jenkins_client(instance_id)
         except Exception as e:
             return {
-                "job_name": job_name,
+                "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
                 "error": f"Jenkins instance resolution failed: {str(e)}",
                 "instructions": self.get_instance_instructions(),
             }
 
-        # to_jenkins_api_path() normalizes internally; pass raw input and
-        # keep a single explicit normalize_job_name() call for the
-        # response's canonical echo.
-        normalized_job = JobNameParser.normalize_job_name(job_name)
         api_job_path = JobNameParser.to_jenkins_api_path(job_name)
         base_url = jenkins_client.config.url.rstrip("/")
         base_tree = tree_override if tree_override else DEFAULT_LIST_TREE
@@ -236,21 +237,22 @@ class GetBuildInfoTool(JenkinsOperationTool):
         depth = kwargs.get("depth") if kwargs.get("depth") is not None else 1
         tree_override = (kwargs.get("tree") or "").strip()
 
+        # Compute the canonical echo up-front so every return path shows the
+        # same job_name value. to_jenkins_api_path() normalizes internally,
+        # so pass raw input there and reuse normalized_job only in responses.
+        normalized_job = JobNameParser.normalize_job_name(job_name)
+
         try:
             instance_id = self.resolve_jenkins_instance(jenkins_url)
             jenkins_client = self.get_jenkins_client(instance_id)
         except Exception as e:
             return {
-                "job_name": job_name,
+                "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
                 "error": f"Jenkins instance resolution failed: {str(e)}",
                 "instructions": self.get_instance_instructions(),
             }
 
-        # to_jenkins_api_path() normalizes internally; pass raw input and
-        # keep a single explicit normalize_job_name() call for the
-        # response's canonical echo.
-        normalized_job = JobNameParser.normalize_job_name(job_name)
         api_job_path = JobNameParser.to_jenkins_api_path(job_name)
         base_url = jenkins_client.config.url.rstrip("/")
         build_segment = str(build_number) if build_number is not None else "lastBuild"

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -1,0 +1,289 @@
+"""Tools for enumerating and inspecting Jenkins builds.
+
+These tools let callers select a specific build to act on *before* invoking
+log/diagnostic tools:
+
+- ``list_job_builds`` returns recent builds with filterable metadata so an AI
+  assistant can pick one by description, duration, timestamp, or result.
+- ``get_build_info`` returns metadata for a single build (or ``lastBuild``)
+  when the caller already knows which build they want.
+
+Both tools are thin wrappers around Jenkins' ``/api/json`` endpoint using the
+already-authenticated HTTP session on ``JenkinsClient``.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from ..base import ParameterSpec
+from ..jenkins.jenkins_client import JenkinsClient
+from ..jenkins.job_name_utils import JobNameParser
+from .base_tools import JenkinsOperationTool
+from .common import CommonParameters
+
+DEFAULT_LIST_TREE = (
+    "builds[number,result,timestamp,duration,description,displayName,url]"
+)
+DEFAULT_LIST_COUNT = 25
+MAX_LIST_COUNT = 500
+MIN_LIST_COUNT = 1
+
+
+def _clamp_count(value: Any) -> int:
+    """Coerce ``count`` to a safe int within ``[MIN_LIST_COUNT, MAX_LIST_COUNT]``."""
+    try:
+        n = int(value) if value is not None else DEFAULT_LIST_COUNT
+    except (TypeError, ValueError):
+        n = DEFAULT_LIST_COUNT
+    return max(MIN_LIST_COUNT, min(n, MAX_LIST_COUNT))
+
+
+class ListJobBuildsTool(JenkinsOperationTool):
+    """Lists recent builds of a Jenkins job with metadata for filtering."""
+
+    def __init__(self, jenkins_client: JenkinsClient, multi_jenkins_manager=None):
+        super().__init__(
+            jenkins_client=jenkins_client,
+            multi_jenkins_manager=multi_jenkins_manager,
+        )
+
+    @property
+    def name(self) -> str:
+        return "list_job_builds"
+
+    @property
+    def description(self) -> str:
+        return (
+            "📋 LIST BUILDS: Returns recent builds for a Jenkins job with metadata "
+            "(number, result, timestamp, duration, description, displayName, url), "
+            "so callers can pick a specific build by criteria before calling "
+            "log-analysis tools. IMPORTANT: jenkins_url is required because jobs "
+            "are load-balanced across multiple Jenkins servers."
+        )
+
+    @property
+    def parameters(self) -> List[ParameterSpec]:
+        return [
+            CommonParameters.job_name_param(),
+            CommonParameters.jenkins_url_param(),
+            ParameterSpec(
+                "count",
+                int,
+                (
+                    f"Maximum number of recent builds to return "
+                    f"(default {DEFAULT_LIST_COUNT}, min {MIN_LIST_COUNT}, "
+                    f"max {MAX_LIST_COUNT})."
+                ),
+                required=False,
+                default=DEFAULT_LIST_COUNT,
+            ),
+            ParameterSpec(
+                "tree",
+                str,
+                (
+                    "Optional Jenkins 'tree' filter for the builds[] array, without "
+                    "the trailing range. Example: 'builds[number,result,description]'. "
+                    "When omitted, a default tree with common metadata fields is used."
+                ),
+                required=False,
+                default="",
+            ),
+        ]
+
+    def _execute_impl(self, **kwargs) -> Dict[str, Any]:
+        job_name = kwargs["job_name"]
+        jenkins_url = kwargs["jenkins_url"]
+        count = _clamp_count(kwargs.get("count"))
+        tree_override = (kwargs.get("tree") or "").strip()
+
+        try:
+            instance_id = self.resolve_jenkins_instance(jenkins_url)
+            jenkins_client = self.get_jenkins_client(instance_id)
+        except Exception as e:
+            return {
+                "job_name": job_name,
+                "jenkins_url": jenkins_url,
+                "error": f"Jenkins instance resolution failed: {str(e)}",
+                "instructions": self.get_instance_instructions(),
+            }
+
+        normalized_job = JobNameParser.normalize_job_name(job_name)
+        api_job_path = JobNameParser.to_jenkins_api_path(normalized_job)
+        base_url = jenkins_client.config.url.rstrip("/")
+        base_tree = tree_override if tree_override else DEFAULT_LIST_TREE
+        tree_value = f"{base_tree}{{0,{count}}}"
+        api_url = f"{base_url}/{api_job_path}/api/json"
+
+        try:
+            response = jenkins_client.connection.session.get(
+                api_url,
+                params={"tree": tree_value},
+                timeout=jenkins_client.config.timeout,
+            )
+            if response.status_code == 404:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "api_url": api_url,
+                    "error": (
+                        "Job not found (HTTP 404). Verify the job_name and "
+                        "that the account has permission to view it."
+                    ),
+                }
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "api_url": api_url,
+                "error": f"Jenkins API request failed: {str(e)}",
+            }
+        except ValueError as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "api_url": api_url,
+                "error": f"Invalid JSON response from Jenkins: {str(e)}",
+            }
+
+        builds = payload.get("builds") or []
+        return {
+            "job_name": normalized_job,
+            "jenkins_url": jenkins_url,
+            "tree": tree_value,
+            "count": len(builds),
+            "builds": builds,
+        }
+
+
+class GetBuildInfoTool(JenkinsOperationTool):
+    """Fetches metadata for a single Jenkins build (or ``lastBuild``)."""
+
+    def __init__(self, jenkins_client: JenkinsClient, multi_jenkins_manager=None):
+        super().__init__(
+            jenkins_client=jenkins_client,
+            multi_jenkins_manager=multi_jenkins_manager,
+        )
+
+    @property
+    def name(self) -> str:
+        return "get_build_info"
+
+    @property
+    def description(self) -> str:
+        return (
+            "ℹ️ BUILD INFO: Returns metadata for a single Jenkins build (number, "
+            "result, timestamp, duration, description, parameters, url, ...). "
+            "When build_number is omitted, the job's 'lastBuild' is returned. "
+            "IMPORTANT: jenkins_url is required because jobs are load-balanced "
+            "across multiple Jenkins servers."
+        )
+
+    @property
+    def parameters(self) -> List[ParameterSpec]:
+        return [
+            CommonParameters.job_name_param(),
+            CommonParameters.jenkins_url_param(),
+            ParameterSpec(
+                "build_number",
+                int,
+                "Build number to fetch. If omitted, the job's 'lastBuild' is returned.",
+                required=False,
+                default=None,
+            ),
+            ParameterSpec(
+                "depth",
+                int,
+                (
+                    "Jenkins API 'depth' parameter controlling nested field "
+                    "expansion (default 1). Ignored when 'tree' is provided."
+                ),
+                required=False,
+                default=1,
+            ),
+            ParameterSpec(
+                "tree",
+                str,
+                (
+                    "Optional Jenkins 'tree' filter to restrict returned fields. "
+                    "Example: 'number,result,timestamp,description'. "
+                    "If omitted, 'depth' is used instead."
+                ),
+                required=False,
+                default="",
+            ),
+        ]
+
+    def _execute_impl(self, **kwargs) -> Dict[str, Any]:
+        job_name = kwargs["job_name"]
+        jenkins_url = kwargs["jenkins_url"]
+        build_number: Optional[int] = kwargs.get("build_number")
+        depth = kwargs.get("depth") if kwargs.get("depth") is not None else 1
+        tree_override = (kwargs.get("tree") or "").strip()
+
+        try:
+            instance_id = self.resolve_jenkins_instance(jenkins_url)
+            jenkins_client = self.get_jenkins_client(instance_id)
+        except Exception as e:
+            return {
+                "job_name": job_name,
+                "jenkins_url": jenkins_url,
+                "error": f"Jenkins instance resolution failed: {str(e)}",
+                "instructions": self.get_instance_instructions(),
+            }
+
+        normalized_job = JobNameParser.normalize_job_name(job_name)
+        api_job_path = JobNameParser.to_jenkins_api_path(normalized_job)
+        base_url = jenkins_client.config.url.rstrip("/")
+        build_segment = str(build_number) if build_number is not None else "lastBuild"
+        api_url = f"{base_url}/{api_job_path}/{build_segment}/api/json"
+        params: Dict[str, Any] = (
+            {"tree": tree_override} if tree_override else {"depth": depth}
+        )
+
+        try:
+            response = jenkins_client.connection.session.get(
+                api_url,
+                params=params,
+                timeout=jenkins_client.config.timeout,
+            )
+            if response.status_code == 404:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "build_number": build_number,
+                    "api_url": api_url,
+                    "error": (
+                        "Build not found (HTTP 404). The job may not exist, "
+                        "have no builds yet, or the specified build number "
+                        "may be out of range."
+                    ),
+                }
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "build_number": build_number,
+                "api_url": api_url,
+                "error": f"Jenkins API request failed: {str(e)}",
+            }
+        except ValueError as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "build_number": build_number,
+                "api_url": api_url,
+                "error": f"Invalid JSON response from Jenkins: {str(e)}",
+            }
+
+        return {
+            "job_name": normalized_job,
+            "jenkins_url": jenkins_url,
+            "requested_build_number": build_number,
+            "resolved_build_number": payload.get("number"),
+            "build": payload,
+        }

--- a/tests/test_cli_http_transport_args.py
+++ b/tests/test_cli_http_transport_args.py
@@ -51,4 +51,3 @@ def test_streamable_http_cli_applies_host_port_and_path(monkeypatch):
     assert dummy.settings.port == 1234
     assert dummy.settings.streamable_http_path == "/custom"
     assert dummy.run_calls == [{"transport": "streamable-http", "mount_path": None}]
-

--- a/tests/tools/test_builds.py
+++ b/tests/tools/test_builds.py
@@ -331,13 +331,16 @@ class TestListJobBuildsToolExecution:
         tool = ListJobBuildsTool(jenkins_client=None, multi_jenkins_manager=manager)
 
         result = tool.execute(
-            job_name="my-pipeline",
+            job_name="/job/TeamA/job/my-pipeline",
             jenkins_url="https://unknown.example.com",
         )
 
         assert result.success is True  # structured error, not a raised exception
         assert "resolution failed" in result.data["error"]
         assert "instructions" in result.data
+        # The resolution-failure path must echo the normalized job_name so
+        # callers read a stable value across success and error responses.
+        assert result.data["job_name"] == "TeamA/my-pipeline"
 
     def test_multi_instance_resolution_routes_to_resolved_client(self):
         response = _make_response(json_payload={"builds": []})
@@ -534,7 +537,7 @@ class TestGetBuildInfoToolExecution:
         tool = GetBuildInfoTool(jenkins_client=None, multi_jenkins_manager=manager)
 
         result = tool.execute(
-            job_name="my-pipeline",
+            job_name="/job/TeamA/job/my-pipeline",
             jenkins_url="https://unknown.example.com",
             build_number=1,
         )
@@ -542,6 +545,9 @@ class TestGetBuildInfoToolExecution:
         assert result.success is True
         assert "resolution failed" in result.data["error"]
         assert "instructions" in result.data
+        # Resolution-failure path echoes the normalized job_name, matching
+        # the success and HTTP-error payloads.
+        assert result.data["job_name"] == "TeamA/my-pipeline"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_builds.py
+++ b/tests/tools/test_builds.py
@@ -92,9 +92,6 @@ class TestClampCount:
     def test_passthrough_valid(self):
         assert _clamp_count(50) == 50
 
-    def test_coerces_numeric_string(self):
-        assert _clamp_count("42") == 42
-
 
 # ---------------------------------------------------------------------------
 # ListJobBuildsTool — static metadata
@@ -156,7 +153,8 @@ class TestListJobBuildsToolExecution:
         assert result.success is True
         data = result.data
         assert data["job_name"] == "TeamA/my-pipeline"
-        assert data["count"] == 2
+        assert data["requested_count"] == DEFAULT_LIST_COUNT
+        assert data["returned_count"] == 2
         assert len(data["builds"]) == 2
 
         call = client.connection.session.get.call_args
@@ -167,6 +165,23 @@ class TestListJobBuildsToolExecution:
             f"{DEFAULT_LIST_TREE}{{0,{DEFAULT_LIST_COUNT}}}"
         )
         assert call.kwargs["timeout"] == client.config.timeout
+
+    def test_numeric_string_count_is_coerced_via_parameter_spec(self):
+        """ParameterSpec(int) coerces ``count="42"`` to int before _clamp_count."""
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            count="42",
+        )
+
+        assert result.success is True
+        tree_arg = client.connection.session.get.call_args.kwargs["params"]["tree"]
+        assert tree_arg.endswith("{0,42}")
+        assert result.data["requested_count"] == 42
 
     def test_custom_count_is_applied_and_clamped(self):
         response = _make_response(json_payload={"builds": []})
@@ -255,7 +270,7 @@ class TestListJobBuildsToolExecution:
 
         assert result.success is True
         assert result.data["builds"] == []
-        assert result.data["count"] == 0
+        assert result.data["returned_count"] == 0
 
     def test_404_returns_structured_error(self):
         response = _make_response(status_code=404, json_payload={})

--- a/tests/tools/test_builds.py
+++ b/tests/tools/test_builds.py
@@ -476,6 +476,10 @@ class TestGetBuildInfoToolExecution:
         assert "error" in data
         assert "404" in data["error"]
         assert "build" not in data
+        # Error payload must echo the requested build number under the same
+        # key used by the success payload (see PR #28 review feedback).
+        assert data["requested_build_number"] == 999
+        assert "build_number" not in data
 
     def test_request_exception_is_captured(self):
         client = _make_jenkins_client(
@@ -489,8 +493,13 @@ class TestGetBuildInfoToolExecution:
         )
 
         assert result.success is True
-        assert "Jenkins API request failed" in result.data["error"]
-        assert "slow jenkins" in result.data["error"]
+        data = result.data
+        assert "Jenkins API request failed" in data["error"]
+        assert "slow jenkins" in data["error"]
+        # No explicit build_number was passed, so the lastBuild path is used
+        # and requested_build_number is None.
+        assert data["requested_build_number"] is None
+        assert "build_number" not in data
 
     def test_invalid_json_is_captured(self):
         response = _make_response(raise_on_json=ValueError("bad payload"))
@@ -503,7 +512,10 @@ class TestGetBuildInfoToolExecution:
         )
 
         assert result.success is True
-        assert "Invalid JSON response" in result.data["error"]
+        data = result.data
+        assert "Invalid JSON response" in data["error"]
+        assert data["requested_build_number"] is None
+        assert "build_number" not in data
 
     def test_multi_instance_resolution_failure(self):
         manager = MagicMock()

--- a/tests/tools/test_builds.py
+++ b/tests/tools/test_builds.py
@@ -82,12 +82,6 @@ def _make_jenkins_client(
 
 
 class TestClampCount:
-    def test_default_when_none(self):
-        assert _clamp_count(None) == DEFAULT_LIST_COUNT
-
-    def test_default_when_non_numeric(self):
-        assert _clamp_count("not-a-number") == DEFAULT_LIST_COUNT
-
     def test_clamps_below_min(self):
         assert _clamp_count(0) == MIN_LIST_COUNT
         assert _clamp_count(-50) == MIN_LIST_COUNT
@@ -305,7 +299,7 @@ class TestListJobBuildsToolExecution:
         assert result.success is True
         assert "Invalid JSON response" in result.data["error"]
 
-    def test_missing_required_param_raises(self):
+    def test_missing_required_param_returns_error_result(self):
         client = _make_jenkins_client()
         tool = ListJobBuildsTool(jenkins_client=client)
 

--- a/tests/tools/test_builds.py
+++ b/tests/tools/test_builds.py
@@ -1,0 +1,551 @@
+"""Unit tests for ``tools.builds`` (list_job_builds, get_build_info).
+
+These tests do not talk to a real Jenkins server. They stub the
+``JenkinsClient`` (and the underlying ``requests`` session) so we can assert
+URL construction, parameter handling, error paths, and multi-instance
+resolution behavior.
+"""
+
+from types import SimpleNamespace
+from typing import Optional
+from unittest.mock import MagicMock
+
+import requests
+
+from jenkins_mcp_enterprise.base import ToolResult
+from jenkins_mcp_enterprise.tools.builds import (
+    DEFAULT_LIST_COUNT,
+    DEFAULT_LIST_TREE,
+    MAX_LIST_COUNT,
+    MIN_LIST_COUNT,
+    GetBuildInfoTool,
+    ListJobBuildsTool,
+    _clamp_count,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(
+    *,
+    status_code: int = 200,
+    json_payload=None,
+    raise_on_json: Optional[Exception] = None,
+) -> MagicMock:
+    """Build a requests.Response-like MagicMock."""
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    if raise_on_json is not None:
+        response.json.side_effect = raise_on_json
+    else:
+        response.json.return_value = json_payload if json_payload is not None else {}
+
+    def _raise_for_status():
+        if status_code >= 400:
+            err = requests.HTTPError(f"HTTP {status_code}")
+            err.response = response
+            raise err
+
+    response.raise_for_status.side_effect = _raise_for_status
+    return response
+
+
+def _make_jenkins_client(
+    *,
+    base_url: str = "https://jenkins.example.com",
+    timeout: int = 30,
+    get_response: Optional[MagicMock] = None,
+    get_side_effect: Optional[Exception] = None,
+) -> MagicMock:
+    """Build a minimal JenkinsClient stand-in with ``.config`` and ``.connection.session``."""
+    session = MagicMock()
+    if get_side_effect is not None:
+        session.get.side_effect = get_side_effect
+    else:
+        session.get.return_value = (
+            get_response
+            if get_response is not None
+            else _make_response(json_payload={})
+        )
+
+    client = MagicMock()
+    client.config = SimpleNamespace(url=base_url, timeout=timeout)
+    client.connection = SimpleNamespace(session=session)
+    return client
+
+
+# ---------------------------------------------------------------------------
+# _clamp_count
+# ---------------------------------------------------------------------------
+
+
+class TestClampCount:
+    def test_default_when_none(self):
+        assert _clamp_count(None) == DEFAULT_LIST_COUNT
+
+    def test_default_when_non_numeric(self):
+        assert _clamp_count("not-a-number") == DEFAULT_LIST_COUNT
+
+    def test_clamps_below_min(self):
+        assert _clamp_count(0) == MIN_LIST_COUNT
+        assert _clamp_count(-50) == MIN_LIST_COUNT
+
+    def test_clamps_above_max(self):
+        assert _clamp_count(10_000) == MAX_LIST_COUNT
+
+    def test_passthrough_valid(self):
+        assert _clamp_count(50) == 50
+
+    def test_coerces_numeric_string(self):
+        assert _clamp_count("42") == 42
+
+
+# ---------------------------------------------------------------------------
+# ListJobBuildsTool — static metadata
+# ---------------------------------------------------------------------------
+
+
+class TestListJobBuildsToolMetadata:
+    def test_name(self):
+        tool = ListJobBuildsTool(jenkins_client=_make_jenkins_client())
+        assert tool.name == "list_job_builds"
+
+    def test_description_mentions_url_requirement(self):
+        tool = ListJobBuildsTool(jenkins_client=_make_jenkins_client())
+        assert "jenkins_url" in tool.description
+
+    def test_parameters_shape(self):
+        tool = ListJobBuildsTool(jenkins_client=_make_jenkins_client())
+        by_name = {p.name: p for p in tool.parameters}
+
+        assert by_name["job_name"].required is True
+        assert by_name["jenkins_url"].required is True
+        assert by_name["count"].required is False
+        assert by_name["count"].default == DEFAULT_LIST_COUNT
+        assert by_name["tree"].required is False
+
+    def test_mcp_schema_required_fields(self):
+        tool = ListJobBuildsTool(jenkins_client=_make_jenkins_client())
+        schema = tool.to_mcp_schema()
+        required = schema["inputSchema"]["required"]
+        assert "job_name" in required
+        assert "jenkins_url" in required
+        assert "count" not in required
+        assert "tree" not in required
+
+
+# ---------------------------------------------------------------------------
+# ListJobBuildsTool — behavior
+# ---------------------------------------------------------------------------
+
+
+class TestListJobBuildsToolExecution:
+    def test_happy_path_uses_default_tree_and_count(self):
+        response = _make_response(
+            json_payload={
+                "builds": [
+                    {"number": 3, "result": "SUCCESS"},
+                    {"number": 2, "result": "FAILURE"},
+                ]
+            }
+        )
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result: ToolResult = tool.execute(
+            job_name="TeamA/my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        data = result.data
+        assert data["job_name"] == "TeamA/my-pipeline"
+        assert data["count"] == 2
+        assert len(data["builds"]) == 2
+
+        call = client.connection.session.get.call_args
+        assert call.args[0] == (
+            "https://jenkins.example.com/job/TeamA/job/my-pipeline/api/json"
+        )
+        assert call.kwargs["params"]["tree"] == (
+            f"{DEFAULT_LIST_TREE}{{0,{DEFAULT_LIST_COUNT}}}"
+        )
+        assert call.kwargs["timeout"] == client.config.timeout
+
+    def test_custom_count_is_applied_and_clamped(self):
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            count=10_000,
+        )
+
+        tree_arg = client.connection.session.get.call_args.kwargs["params"]["tree"]
+        assert tree_arg.endswith(f"{{0,{MAX_LIST_COUNT}}}")
+
+    def test_custom_tree_override_is_used(self):
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        custom_tree = "builds[number,result,description]"
+        tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            count=5,
+            tree=custom_tree,
+        )
+
+        tree_arg = client.connection.session.get.call_args.kwargs["params"]["tree"]
+        assert tree_arg == f"{custom_tree}{{0,5}}"
+
+    def test_empty_tree_override_falls_back_to_default(self):
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            tree="   ",
+        )
+
+        tree_arg = client.connection.session.get.call_args.kwargs["params"]["tree"]
+        assert tree_arg.startswith(DEFAULT_LIST_TREE)
+
+    def test_base_url_trailing_slash_is_stripped(self):
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(
+            base_url="https://jenkins.example.com/",
+            get_response=response,
+        )
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        api_url = client.connection.session.get.call_args.args[0]
+        assert api_url == "https://jenkins.example.com/job/my-pipeline/api/json"
+
+    def test_leading_slash_and_job_prefixes_are_normalized(self):
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        tool.execute(
+            job_name="/job/TeamA/job/my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        api_url = client.connection.session.get.call_args.args[0]
+        assert api_url == (
+            "https://jenkins.example.com/job/TeamA/job/my-pipeline/api/json"
+        )
+
+    def test_missing_builds_key_returns_empty_list(self):
+        response = _make_response(json_payload={})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        assert result.data["builds"] == []
+        assert result.data["count"] == 0
+
+    def test_404_returns_structured_error(self):
+        response = _make_response(status_code=404, json_payload={})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="missing-job",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        data = result.data
+        assert "error" in data
+        assert "404" in data["error"]
+        assert "builds" not in data
+
+    def test_request_exception_is_captured(self):
+        client = _make_jenkins_client(get_side_effect=requests.ConnectionError("boom"))
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True  # tool returns an error dict, not a raised exc
+        assert "Jenkins API request failed" in result.data["error"]
+        assert "boom" in result.data["error"]
+
+    def test_invalid_json_is_captured(self):
+        response = _make_response(raise_on_json=ValueError("not json"))
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        assert "Invalid JSON response" in result.data["error"]
+
+    def test_missing_required_param_raises(self):
+        client = _make_jenkins_client()
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(jenkins_url="https://jenkins.example.com")
+
+        assert result.success is False
+        assert "job_name" in (result.error_message or "")
+
+    def test_multi_instance_resolution_failure(self):
+        manager = MagicMock()
+        manager.resolve_jenkins_url.side_effect = ValueError("no matching instance")
+        manager.get_usage_instructions.return_value = "configure instances in YAML"
+
+        tool = ListJobBuildsTool(jenkins_client=None, multi_jenkins_manager=manager)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://unknown.example.com",
+        )
+
+        assert result.success is True  # structured error, not a raised exception
+        assert "resolution failed" in result.data["error"]
+        assert "instructions" in result.data
+
+    def test_multi_instance_resolution_routes_to_resolved_client(self):
+        response = _make_response(json_payload={"builds": []})
+        resolved_client = _make_jenkins_client(
+            base_url="https://jenkins-eu.example.com",
+            get_response=response,
+        )
+
+        manager = MagicMock()
+        manager.resolve_jenkins_url.return_value = "eu"
+        manager.get_jenkins_client.return_value = resolved_client
+
+        tool = ListJobBuildsTool(jenkins_client=None, multi_jenkins_manager=manager)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins-eu.example.com",
+        )
+
+        assert result.success is True
+        manager.resolve_jenkins_url.assert_called_once_with(
+            "https://jenkins-eu.example.com"
+        )
+        manager.get_jenkins_client.assert_called_once_with("eu")
+        assert resolved_client.connection.session.get.called
+
+
+# ---------------------------------------------------------------------------
+# GetBuildInfoTool — static metadata
+# ---------------------------------------------------------------------------
+
+
+class TestGetBuildInfoToolMetadata:
+    def test_name(self):
+        tool = GetBuildInfoTool(jenkins_client=_make_jenkins_client())
+        assert tool.name == "get_build_info"
+
+    def test_parameters_shape(self):
+        tool = GetBuildInfoTool(jenkins_client=_make_jenkins_client())
+        by_name = {p.name: p for p in tool.parameters}
+
+        assert by_name["job_name"].required is True
+        assert by_name["jenkins_url"].required is True
+        assert by_name["build_number"].required is False
+        assert by_name["build_number"].default is None
+        assert by_name["depth"].default == 1
+        assert by_name["tree"].required is False
+
+
+# ---------------------------------------------------------------------------
+# GetBuildInfoTool — behavior
+# ---------------------------------------------------------------------------
+
+
+class TestGetBuildInfoToolExecution:
+    def test_explicit_build_number_url(self):
+        response = _make_response(
+            json_payload={"number": 42, "result": "SUCCESS", "duration": 1000}
+        )
+        client = _make_jenkins_client(get_response=response)
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="TeamA/my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            build_number=42,
+        )
+
+        assert result.success is True
+        data = result.data
+        assert data["requested_build_number"] == 42
+        assert data["resolved_build_number"] == 42
+        assert data["build"]["result"] == "SUCCESS"
+
+        call = client.connection.session.get.call_args
+        assert call.args[0] == (
+            "https://jenkins.example.com/job/TeamA/job/my-pipeline/42/api/json"
+        )
+        assert call.kwargs["params"] == {"depth": 1}
+
+    def test_last_build_when_number_omitted(self):
+        response = _make_response(json_payload={"number": 99, "result": "SUCCESS"})
+        client = _make_jenkins_client(get_response=response)
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        data = result.data
+        assert data["requested_build_number"] is None
+        assert data["resolved_build_number"] == 99
+
+        api_url = client.connection.session.get.call_args.args[0]
+        assert api_url == (
+            "https://jenkins.example.com/job/my-pipeline/lastBuild/api/json"
+        )
+
+    def test_tree_override_takes_precedence_over_depth(self):
+        response = _make_response(json_payload={"number": 5})
+        client = _make_jenkins_client(get_response=response)
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            build_number=5,
+            depth=2,
+            tree="number,result,description",
+        )
+
+        params = client.connection.session.get.call_args.kwargs["params"]
+        assert params == {"tree": "number,result,description"}
+
+    def test_custom_depth_is_forwarded(self):
+        response = _make_response(json_payload={"number": 5})
+        client = _make_jenkins_client(get_response=response)
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            build_number=5,
+            depth=3,
+        )
+
+        params = client.connection.session.get.call_args.kwargs["params"]
+        assert params == {"depth": 3}
+
+    def test_404_returns_structured_error(self):
+        response = _make_response(status_code=404, json_payload={})
+        client = _make_jenkins_client(get_response=response)
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            build_number=999,
+        )
+
+        assert result.success is True
+        data = result.data
+        assert "error" in data
+        assert "404" in data["error"]
+        assert "build" not in data
+
+    def test_request_exception_is_captured(self):
+        client = _make_jenkins_client(
+            get_side_effect=requests.Timeout("slow jenkins"),
+        )
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        assert "Jenkins API request failed" in result.data["error"]
+        assert "slow jenkins" in result.data["error"]
+
+    def test_invalid_json_is_captured(self):
+        response = _make_response(raise_on_json=ValueError("bad payload"))
+        client = _make_jenkins_client(get_response=response)
+        tool = GetBuildInfoTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        assert "Invalid JSON response" in result.data["error"]
+
+    def test_multi_instance_resolution_failure(self):
+        manager = MagicMock()
+        manager.resolve_jenkins_url.side_effect = ValueError("no matching instance")
+        manager.get_usage_instructions.return_value = "configure instances"
+
+        tool = GetBuildInfoTool(jenkins_client=None, multi_jenkins_manager=manager)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://unknown.example.com",
+            build_number=1,
+        )
+
+        assert result.success is True
+        assert "resolution failed" in result.data["error"]
+        assert "instructions" in result.data
+
+
+# ---------------------------------------------------------------------------
+# Factory registration
+# ---------------------------------------------------------------------------
+
+
+def test_tools_are_registered_by_tool_factory():
+    """Both new tools should appear in ``ToolFactory.create_tools`` output."""
+    from jenkins_mcp_enterprise.di_container import DIContainer
+    from jenkins_mcp_enterprise.tool_factory import ToolFactory
+
+    # spec=DIContainer makes isinstance(mock, DIContainer) return True without
+    # needing a real container (which would require a full config + Jenkins).
+    container = MagicMock(spec=DIContainer)
+    container.get_jenkins_client.return_value = MagicMock()
+    container.get_cache_manager.return_value = MagicMock()
+    vector_manager = MagicMock()
+    vector_manager.vector_search_disabled = True
+    container.get_vector_manager.return_value = vector_manager
+    container.get_multi_jenkins_manager.return_value = None
+
+    factory = ToolFactory(container)
+    tools = factory.create_tools()
+
+    assert "list_job_builds" in tools
+    assert "get_build_info" in tools
+    assert factory.get_tool_count() == 11


### PR DESCRIPTION
## What this adds

Two small tools for selecting a specific build *before* drilling into it with the
existing log/diagnostic tools:

- **`list_job_builds`** — returns recent builds for a job with filter-friendly
  metadata (number, result, timestamp, duration, description, displayName, url).
  Supports `count` (default 25, min 1, max 500) and an optional Jenkins `tree`
  override.
- **`get_build_info`** — returns metadata for a single build, or `lastBuild` when
  `build_number` is omitted. Supports `depth` (default 1) and an optional `tree`
  override.

Both are thin wrappers over Jenkins' `/api/json` endpoint using the
already-authenticated `JenkinsClient` session.

## Why

The existing 10 tools cover diagnosis, triggering, and log exploration once you
*know* which build to look at, but there's no MCP way to **enumerate or identify
a build from metadata first**. The common workaround is for the LLM to fall back
to raw HTTP (`/job/.../api/json?tree=builds[...]`), which bypasses the URL-based
multi-instance routing the server already provides and produces noisier agent
transcripts.

Typical flow this enables:

```
list_job_builds → filter builds by description / duration / timestamp
  → get_build_info (or straight to diagnose_build_failure / navigate_log)
```

## Design

- New module `jenkins_mcp_enterprise/tools/builds.py` (~280 LoC, 2 tools).
- Registration added to `ToolFactory.create_tools()` next to
  `get_jenkins_job_parameters` (same "Build Management" grouping).
- URL construction uses `JobNameParser.normalize_job_name` +
  `to_jenkins_api_path`, consistent with `subbuild_discoverer.py`.
- Multi-instance routing reuses `JenkinsOperationTool.resolve_jenkins_instance`.
- Error paths return structured error dicts (never raise) — matches the pattern
  used by `GetJobParametersTool` and `TriggerBuildTool`.

## Backwards compatibility

No existing tool or behavior is modified. `get_tool_count()` bumped 9 → 11
(without vector) and the README tool count 10 → 12.

## Tests

New `tests/tools/test_builds.py` — **34 tests, 100% line coverage on `builds.py`**.
Covers:

- Static metadata & MCP schema shape
- Default / custom `tree` and `count` (with clamping + numeric-string coercion)
- URL construction: folders, trailing slashes, `/job/` prefixes
- Empty `builds` payload
- 404, network exception, invalid JSON → structured error
- `lastBuild` vs explicit build number
- `tree` takes precedence over `depth`
- Missing required params surface as `ToolResult.error`
- Multi-instance resolution: happy path + failure
- `ToolFactory` registers both tools and reports count 11

All existing tests remain green:

```
python -m pytest tests/tools/ tests/test_basic_validation.py
# 42 passed
```

Formatted with `black`.