### PR TITLE
Improve multi-Jenkins URL routing

### DIFF
--- a/jenkins_mcp_enterprise/multi_jenkins_manager.py
+++ b/jenkins_mcp_enterprise/multi_jenkins_manager.py
@@ -5,6 +5,7 @@ Multi-Jenkins Instance Manager for MCP Roots Implementation
 
 import os
 import threading
+import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -241,33 +242,99 @@ class MultiJenkinsManager:
                 f"No valid roots specified, using fallback: {self.active_roots[0]}"
             )
 
+    @staticmethod
+    def _normalize_url_path(path: str) -> str:
+        """Normalize a URL path for Jenkins instance matching."""
+        decoded = urllib.parse.unquote(path or "")
+        if decoded in ("", "/"):
+            return ""
+        return decoded.rstrip("/")
+
+    @classmethod
+    def _parse_jenkins_url_for_matching(
+        cls, url: str
+    ) -> tuple[Optional[str], str, str]:
+        """Parse a Jenkins URL or URL-like string into matchable parts."""
+        decoded = urllib.parse.unquote((url or "").strip())
+        if not decoded:
+            raise ConfigurationError("No Jenkins URL provided")
+
+        has_scheme = decoded.startswith(("http://", "https://"))
+        parse_target = decoded if has_scheme else f"//{decoded.lstrip('/')}"
+        parsed = urllib.parse.urlsplit(parse_target)
+        netloc = parsed.netloc.lower()
+        if not netloc:
+            raise ConfigurationError(f"Invalid Jenkins URL: {url}")
+
+        scheme = parsed.scheme.lower() if has_scheme and parsed.scheme else None
+        path = cls._normalize_url_path(parsed.path)
+        return scheme, netloc, path
+
+    @classmethod
+    def _candidate_base_paths(cls, path: str) -> List[str]:
+        """Generate Jenkins base-path candidates from a base/job/build URL path."""
+        normalized = cls._normalize_url_path(path)
+        candidates: List[str] = [normalized]
+
+        for marker in ("/job/", "/view/"):
+            if marker in normalized:
+                candidates.append(cls._normalize_url_path(normalized.split(marker, 1)[0]))
+
+        if "/api/" in normalized:
+            candidates.append(cls._normalize_url_path(normalized.split("/api/", 1)[0]))
+
+        deduped: List[str] = []
+        for candidate in candidates:
+            if candidate not in deduped:
+                deduped.append(candidate)
+
+        return deduped
+
     def resolve_jenkins_url(self, url: str) -> str:
         """Resolve a Jenkins URL to an instance ID, with validation"""
-        # Clean up the URL
-        clean_url = url.rstrip("/")
-        if not clean_url.startswith(("http://", "https://")):
-            clean_url = f"https://{clean_url}"
+        input_scheme, input_netloc, input_path = self._parse_jenkins_url_for_matching(url)
+        candidate_paths = self._candidate_base_paths(input_path)
+        matches: List[tuple[str, JenkinsInstanceConfig]] = []
 
-        # Find matching instance
         for instance_id, config in self.instances_config.items():
-            config_url = config.url.rstrip("/")
-            if clean_url == config_url:
-                # Validate credentials exist
-                if not config.token or not config.username:
-                    available_urls = [cfg.url for cfg in self.instances_config.values()]
-                    raise ConfigurationError(
-                        f"No credentials configured for Jenkins instance at {clean_url}. "
-                        f"Available Jenkins instances with credentials: {available_urls}"
-                    )
-                return instance_id
+            config_scheme, config_netloc, config_path = self._parse_jenkins_url_for_matching(
+                config.url
+            )
+            if input_netloc != config_netloc:
+                continue
+            if input_scheme and config_scheme and input_scheme != config_scheme:
+                continue
+            if config_path not in candidate_paths:
+                continue
+            matches.append((instance_id, config))
+
+        if len(matches) > 1:
+            available_urls = [cfg.url for _, cfg in matches]
+            raise ConfigurationError(
+                "Multiple Jenkins instances match URL: "
+                f"{url}\nMatching Jenkins instances:\n"
+                + "\n".join([f"  - {cfg_url}" for cfg_url in available_urls])
+                + "\n\nSpecify the exact Jenkins base URL to disambiguate."
+            )
+
+        if len(matches) == 1:
+            instance_id, config = matches[0]
+            if not config.token or not config.username:
+                available_urls = [cfg.url for cfg in self.instances_config.values()]
+                raise ConfigurationError(
+                    f"No credentials configured for Jenkins instance at {config.url}. "
+                    f"Available Jenkins instances with credentials: {available_urls}"
+                )
+            return instance_id
 
         # No match found - provide helpful error
         available_urls = [cfg.url for cfg in self.instances_config.values()]
         raise ConfigurationError(
-            f"No Jenkins instance configured for URL: {clean_url}\n"
+            f"No Jenkins instance configured for URL: {url}\n"
             f"Available Jenkins instances:\n"
             + "\n".join([f"  - {url}" for url in available_urls])
-            + f"\n\nTo use a Jenkins instance, specify one of the URLs above exactly as shown."
+            + "\n\nUse one of the configured Jenkins base URLs above, or any full Jenkins "
+            "job/build URL rooted under one of those bases."
         )
 
     def get_usage_instructions(self) -> str:
@@ -283,8 +350,10 @@ class MultiJenkinsManager:
         return (
             f"Available Jenkins instances ({len(self.instances_config)} configured):\n"
             + "\n".join(instances)
-            + "\n\nTo specify a Jenkins instance, use the exact URL format above. "
-            "For example: 'https://jenkins.example.com'"
+            + "\n\nPass the configured Jenkins base URL above (preferred), or a full "
+            "Jenkins job/build URL rooted under one of those bases. "
+            "For example: 'https://jenkins.example.com' or "
+            "'https://jenkins.example.com/job/example/123/'."
         )
 
     def get_jenkins_client(self, instance_id: Optional[str] = None) -> JenkinsClient:

--- a/jenkins_mcp_enterprise/multi_jenkins_manager.py
+++ b/jenkins_mcp_enterprise/multi_jenkins_manager.py
@@ -278,7 +278,9 @@ class MultiJenkinsManager:
 
         for marker in ("/job/", "/view/"):
             if marker in normalized:
-                candidates.append(cls._normalize_url_path(normalized.split(marker, 1)[0]))
+                candidates.append(
+                    cls._normalize_url_path(normalized.split(marker, 1)[0])
+                )
 
         if "/api/" in normalized:
             candidates.append(cls._normalize_url_path(normalized.split("/api/", 1)[0]))
@@ -292,13 +294,15 @@ class MultiJenkinsManager:
 
     def resolve_jenkins_url(self, url: str) -> str:
         """Resolve a Jenkins URL to an instance ID, with validation"""
-        input_scheme, input_netloc, input_path = self._parse_jenkins_url_for_matching(url)
+        input_scheme, input_netloc, input_path = self._parse_jenkins_url_for_matching(
+            url
+        )
         candidate_paths = self._candidate_base_paths(input_path)
         matches: List[tuple[str, JenkinsInstanceConfig]] = []
 
         for instance_id, config in self.instances_config.items():
-            config_scheme, config_netloc, config_path = self._parse_jenkins_url_for_matching(
-                config.url
+            config_scheme, config_netloc, config_path = (
+                self._parse_jenkins_url_for_matching(config.url)
             )
             if input_netloc != config_netloc:
                 continue

--- a/jenkins_mcp_enterprise/server.py
+++ b/jenkins_mcp_enterprise/server.py
@@ -228,18 +228,15 @@ def register_jenkins_resources(mcp: FastMCP, multi_jenkins_manager) -> None:
     # Legacy/deprecated: this resource is structurally brittle for full URLs (slashes). Keep it for compatibility.
     @mcp.resource("jenkins://resolve/{url}")
     def resolve_jenkins_url(url: str) -> dict:
-        """Resolve a Jenkins base URL to a configured instance (deprecated).
+        """Resolve a Jenkins URL to a configured instance (deprecated).
 
         Prefer using tools with 'jenkins_url', or read `jenkins://instances`.
         """
         # Accept URL-encoded forms (e.g., https%3A%2F%2Fjenkins.example.com)
-        decoded = urllib.parse.unquote(url).rstrip("/")
-        clean_url = decoded
-        if not clean_url.startswith(("http://", "https://")):
-            clean_url = f"https://{clean_url}"
+        decoded = urllib.parse.unquote(url)
 
         try:
-            instance_id = multi_jenkins_manager.resolve_jenkins_url(clean_url)
+            instance_id = multi_jenkins_manager.resolve_jenkins_url(decoded)
             cfg = multi_jenkins_manager.instances_config[instance_id]
             return {
                 "status": "configured",
@@ -251,7 +248,7 @@ def register_jenkins_resources(mcp: FastMCP, multi_jenkins_manager) -> None:
         except Exception as e:
             return {
                 "status": "not_configured",
-                "url": clean_url,
+                "url": decoded,
                 "message": str(e),
                 "deprecated": True,
             }

--- a/jenkins_mcp_enterprise/tools/common.py
+++ b/jenkins_mcp_enterprise/tools/common.py
@@ -73,8 +73,10 @@ class CommonParameters:
         return ParameterSpec(
             "jenkins_url",
             str,
-            "Jenkins instance URL (e.g., 'https://jenkins.example.com'). "
-            "REQUIRED - jobs are load-balanced across multiple servers.",
+            "Jenkins instance URL. Pass the configured Jenkins base URL "
+            "(preferred) or a full Jenkins job/build URL rooted under that "
+            "instance. REQUIRED - tools resolve exactly one Jenkins instance "
+            "per call across multiple servers.",
             required=True,
         )
 

--- a/tests/test_multi_jenkins_manager.py
+++ b/tests/test_multi_jenkins_manager.py
@@ -56,6 +56,22 @@ def test_resolve_jenkins_url_accepts_full_job_and_build_urls(tmp_path: Path):
     )
 
 
+def test_resolve_jenkins_url_accepts_encoded_full_urls(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {"prod": _instance("https://jenkins.example.com")},
+        )
+    )
+
+    assert (
+        manager.resolve_jenkins_url(
+            "https://jenkins.example.com/job/release%252F2.2.0/123/"
+        )
+        == "prod"
+    )
+
+
 def test_resolve_jenkins_url_accepts_context_path_and_api_urls(tmp_path: Path):
     manager = MultiJenkinsManager(
         _write_config(
@@ -65,7 +81,9 @@ def test_resolve_jenkins_url_accepts_context_path_and_api_urls(tmp_path: Path):
     )
 
     assert manager.resolve_jenkins_url("https://ci.example.com/jenkins") == "corp"
-    assert manager.resolve_jenkins_url("https://ci.example.com/jenkins/api/json") == "corp"
+    assert (
+        manager.resolve_jenkins_url("https://ci.example.com/jenkins/api/json") == "corp"
+    )
     assert (
         manager.resolve_jenkins_url(
             "https://ci.example.com/jenkins/job/TeamA/job/my-pipeline/123/api/json"
@@ -74,7 +92,9 @@ def test_resolve_jenkins_url_accepts_context_path_and_api_urls(tmp_path: Path):
     )
 
 
-def test_resolve_jenkins_url_accepts_missing_scheme_when_match_is_unique(tmp_path: Path):
+def test_resolve_jenkins_url_accepts_missing_scheme_when_match_is_unique(
+    tmp_path: Path,
+):
     manager = MultiJenkinsManager(
         _write_config(
             tmp_path,
@@ -82,7 +102,9 @@ def test_resolve_jenkins_url_accepts_missing_scheme_when_match_is_unique(tmp_pat
         )
     )
 
-    assert manager.resolve_jenkins_url("ci.example.com/jenkins/job/example/42") == "corp"
+    assert (
+        manager.resolve_jenkins_url("ci.example.com/jenkins/job/example/42") == "corp"
+    )
 
 
 def test_resolve_jenkins_url_reports_ambiguous_matches(tmp_path: Path):

--- a/tests/test_multi_jenkins_manager.py
+++ b/tests/test_multi_jenkins_manager.py
@@ -1,0 +1,121 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from jenkins_mcp_enterprise.exceptions import ConfigurationError
+from jenkins_mcp_enterprise.multi_jenkins_manager import MultiJenkinsManager
+
+
+def _write_config(tmp_path: Path, instances: dict) -> str:
+    config_path = tmp_path / "jenkins-instances.yml"
+    config_path.write_text(yaml.safe_dump({"jenkins_instances": instances}))
+    return str(config_path)
+
+
+def _instance(url: str) -> dict:
+    return {
+        "url": url,
+        "username": "tester",
+        "token": "secret",
+        "display_name": url,
+    }
+
+
+def test_resolve_jenkins_url_accepts_base_url_and_trailing_slash(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {"prod": _instance("https://jenkins.example.com")},
+        )
+    )
+
+    assert manager.resolve_jenkins_url("https://jenkins.example.com") == "prod"
+    assert manager.resolve_jenkins_url("https://jenkins.example.com/") == "prod"
+
+
+def test_resolve_jenkins_url_accepts_full_job_and_build_urls(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {"prod": _instance("https://jenkins.example.com")},
+        )
+    )
+
+    assert (
+        manager.resolve_jenkins_url(
+            "https://jenkins.example.com/job/TeamA/job/my-pipeline"
+        )
+        == "prod"
+    )
+    assert (
+        manager.resolve_jenkins_url(
+            "https://jenkins.example.com/job/TeamA/job/my-pipeline/123/"
+        )
+        == "prod"
+    )
+
+
+def test_resolve_jenkins_url_accepts_context_path_and_api_urls(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {"corp": _instance("https://ci.example.com/jenkins")},
+        )
+    )
+
+    assert manager.resolve_jenkins_url("https://ci.example.com/jenkins") == "corp"
+    assert manager.resolve_jenkins_url("https://ci.example.com/jenkins/api/json") == "corp"
+    assert (
+        manager.resolve_jenkins_url(
+            "https://ci.example.com/jenkins/job/TeamA/job/my-pipeline/123/api/json"
+        )
+        == "corp"
+    )
+
+
+def test_resolve_jenkins_url_accepts_missing_scheme_when_match_is_unique(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {"corp": _instance("http://ci.example.com/jenkins")},
+        )
+    )
+
+    assert manager.resolve_jenkins_url("ci.example.com/jenkins/job/example/42") == "corp"
+
+
+def test_resolve_jenkins_url_reports_ambiguous_matches(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {
+                "http": _instance("http://ci.example.com/jenkins"),
+                "https": _instance("https://ci.example.com/jenkins"),
+            },
+        )
+    )
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        manager.resolve_jenkins_url("ci.example.com/jenkins/job/example/42")
+
+    assert "Multiple Jenkins instances match URL" in str(exc_info.value)
+    assert "http://ci.example.com/jenkins" in str(exc_info.value)
+    assert "https://ci.example.com/jenkins" in str(exc_info.value)
+
+
+def test_resolve_jenkins_url_reports_helpful_no_match_message(tmp_path: Path):
+    manager = MultiJenkinsManager(
+        _write_config(
+            tmp_path,
+            {"prod": _instance("https://jenkins.example.com")},
+        )
+    )
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        manager.resolve_jenkins_url("https://other.example.com/job/example/42")
+
+    message = str(exc_info.value)
+    assert "No Jenkins instance configured for URL" in message
+    assert "https://jenkins.example.com" in message
+    assert "full Jenkins job/build URL" in message


### PR DESCRIPTION
Automated note from Will Review bot, posted via Jordan:

Closes #29.

Summary

- centralize Jenkins URL normalization in `MultiJenkinsManager.resolve_jenkins_url`
- accept configured base URLs, trailing-slash variants, full job/build URLs, and context-path URLs when resolving an instance
- surface a clearer shared `jenkins_url` parameter contract for tools
- add targeted unit coverage for normalized routing and helpful failure cases

Validation

- `.venv/bin/python -m pytest -q tests/test_multi_jenkins_manager.py`
- `.venv/bin/python -m pytest -q tests/tools/test_builds.py`