### PR TITLE
Add job definition tools and harden MCP runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Model Context Protocol (MCP) server for Jenkins that provides build management
 - Diagnose build failures with configurable recommendations
 - Route each tool call to the correct Jenkins instance based on `jenkins_url`
 - Expose `semantic_search` only when vector search is enabled
-- Expose `apply_job_xml_edit` only when server-side XML editing is enabled
+- Expose `apply_job_edit` only when server-side job editing is enabled
 
 ## Quick Start
 
@@ -57,12 +57,12 @@ cp config/mcp-config.example.yml config/mcp-config.yml
 
 Edit `config/mcp-config.yml` with your Jenkins URLs and credentials.
 
-If you want the optional Jenkins XML edit workflow for non-SCM-backed jobs, also set:
+If you want the optional Jenkins-managed job edit workflow for non-SCM-backed jobs, also set:
 
 ```yaml
 settings:
-  enable_job_xml_editing: true
-  job_xml_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
+  enable_job_editing: true
+  job_edit_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
 ```
 
 ### Optional Project-Local Diagnostic Override
@@ -121,8 +121,8 @@ Add to `~/.claude_desktop_config.json`:
 - Pass full Jenkins build URLs when a tool or prompt relies on `jenkins_url`.
 - In multi-Jenkins setups, each tool call resolves exactly one configured instance from `jenkins_url`. The server does not fan out across all configured Jenkins instances for a single call.
 - `semantic_search` is available only when vector search is enabled.
-- `apply_job_xml_edit` is available only when `settings.enable_job_xml_editing: true`.
-- `get_job_definition` returns SCM location details for SCM-backed pipelines. For inline or XML-backed jobs, it can stage `config.xml` locally for patch/edit/upload when XML editing is enabled.
+- `apply_job_edit` is available only when `settings.enable_job_editing: true`.
+- `get_job_definition` returns SCM location details for SCM-backed pipelines. For inline pipelines, it stages a local Groovy file for patch/edit/upload. For other Jenkins-managed jobs, it stages `config.xml`.
 - `diagnose_build_failure` always uses a diagnostic config layer. If you do not provide a project-local override, the bundled defaults are used.
 - The Docker image includes `ripgrep`, so `ripgrep_search` and `navigate_log` work in container deployments.
 
@@ -153,7 +153,7 @@ Find similar authentication failures in recent builds
 | `get_log_context` | Fetch targeted log ranges or chunks |
 | `diagnose_build_failure` | AI-assisted failure diagnosis using logs, hierarchy data, and configured recommendations |
 | `semantic_search` | Vector-backed similarity search across log chunks when vector search is enabled |
-| `apply_job_xml_edit` | Upload a locally edited Jenkins `config.xml` back to Jenkins when XML editing is enabled |
+| `apply_job_edit` | Upload a locally edited staged job definition back to Jenkins when job editing is enabled |
 
 ## Configuration Documentation
 

--- a/README.md
+++ b/README.md
@@ -7,11 +7,15 @@ A Model Context Protocol (MCP) server for Jenkins that provides build management
 ## What It Does
 
 - Trigger builds synchronously or asynchronously
+- Find jobs before triggering or inspecting them
+- Inspect job definitions and source locations
 - Retrieve logs and run targeted log-search tools
 - Discover downstream and sub-build hierarchies
+- Inspect recent builds or a window around a specific build
 - Diagnose build failures with configurable recommendations
 - Route each tool call to the correct Jenkins instance based on `jenkins_url`
 - Expose `semantic_search` only when vector search is enabled
+- Expose `apply_job_xml_edit` only when server-side XML editing is enabled
 
 ## Quick Start
 
@@ -52,6 +56,14 @@ cp config/mcp-config.example.yml config/mcp-config.yml
 ```
 
 Edit `config/mcp-config.yml` with your Jenkins URLs and credentials.
+
+If you want the optional Jenkins XML edit workflow for non-SCM-backed jobs, also set:
+
+```yaml
+settings:
+  enable_job_xml_editing: true
+  job_xml_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
+```
 
 ### Optional Project-Local Diagnostic Override
 
@@ -109,6 +121,8 @@ Add to `~/.claude_desktop_config.json`:
 - Pass full Jenkins build URLs when a tool or prompt relies on `jenkins_url`.
 - In multi-Jenkins setups, each tool call resolves exactly one configured instance from `jenkins_url`. The server does not fan out across all configured Jenkins instances for a single call.
 - `semantic_search` is available only when vector search is enabled.
+- `apply_job_xml_edit` is available only when `settings.enable_job_xml_editing: true`.
+- `get_job_definition` returns SCM location details for SCM-backed pipelines. For inline or XML-backed jobs, it can stage `config.xml` locally for patch/edit/upload when XML editing is enabled.
 - `diagnose_build_failure` always uses a diagnostic config layer. If you do not provide a project-local override, the bundled defaults are used.
 - The Docker image includes `ripgrep`, so `ripgrep_search` and `navigate_log` work in container deployments.
 
@@ -125,16 +139,21 @@ Find similar authentication failures in recent builds
 
 | Tool | Purpose |
 |------|---------|
-| `diagnose_build_failure` | AI-assisted failure diagnosis using logs, hierarchy data, and configured recommendations |
-| `semantic_search` | Vector-backed similarity search across log chunks when vector search is enabled |
 | `trigger_build` | Start a build and wait for completion |
 | `trigger_build_async` | Queue a build without waiting for completion |
 | `trigger_build_with_subs` | Trigger a build and track downstream/sub-build execution |
 | `get_jenkins_job_parameters` | Inspect job parameters before triggering builds |
+| `find_jobs` | Search jobs by name, path, or URL on one resolved Jenkins instance |
+| `list_job_builds` | List recent builds for a job, or a small window around a target build number |
+| `get_build_info` | Fetch metadata for a specific build or `lastBuild` |
+| `get_job_definition` | Inspect whether a job is SCM-backed, inline, multibranch, or XML-backed |
 | `ripgrep_search` | Search logs with regex and context windows |
 | `filter_errors_grep` | Filter logs with common error-oriented patterns |
 | `navigate_log` | Jump to sections or occurrences inside a log |
 | `get_log_context` | Fetch targeted log ranges or chunks |
+| `diagnose_build_failure` | AI-assisted failure diagnosis using logs, hierarchy data, and configured recommendations |
+| `semantic_search` | Vector-backed similarity search across log chunks when vector search is enabled |
+| `apply_job_xml_edit` | Upload a locally edited Jenkins `config.xml` back to Jenkins when XML editing is enabled |
 
 ## Configuration Documentation
 

--- a/config/README.md
+++ b/config/README.md
@@ -43,12 +43,12 @@ vector:
 
 5. If you want to tune `diagnose_build_failure`, add `config/diagnostic-parameters.yml`.
 
-6. If you want the optional Jenkins XML edit workflow for non-SCM-backed jobs, set:
+6. If you want the optional Jenkins-managed job edit workflow for non-SCM-backed jobs, set:
 
 ```yaml
 settings:
-  enable_job_xml_editing: true
-  job_xml_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
+  enable_job_editing: true
+  job_edit_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
 ```
 
 7. Start the server with:
@@ -101,10 +101,10 @@ Global behavior:
 - `auto_discover_instances`
 - `log_instance_switching`
 - `log_health_checks`
-- `enable_job_xml_editing`
-- `job_xml_workspace_dir`
+- `enable_job_editing`
+- `job_edit_workspace_dir`
 
-`enable_job_xml_editing` is `false` by default. When enabled, `get_job_definition` can download a Jenkins job `config.xml` into the local workspace directory, and the server registers `apply_job_xml_edit` so the edited XML can be uploaded back to Jenkins. This is intended for Jenkins-managed XML jobs and inline pipeline definitions, not SCM-backed Jenkinsfiles.
+`enable_job_editing` is `false` by default. When enabled, `get_job_definition` can stage Jenkins-managed job definitions into the local workspace directory, and the server registers `apply_job_edit` so validated edits can be uploaded back to Jenkins. Inline pipelines are staged as Groovy files; XML-managed jobs are staged as `config.xml`. SCM-backed Jenkinsfiles are still edited in source control, not through Jenkins MCP. The older `enable_job_xml_editing` and `job_xml_workspace_dir` keys are still accepted as aliases.
 
 ### `vector`
 
@@ -115,7 +115,7 @@ Controls semantic search. If `disable_vector_search: true`, the `semantic_search
 The tool surface is mostly static, with two conditional tools:
 
 - `semantic_search` is registered only when vector search is enabled
-- `apply_job_xml_edit` is registered only when `settings.enable_job_xml_editing: true`
+- `apply_job_edit` is registered only when `settings.enable_job_editing: true`
 
 The main always-on tool set includes:
 

--- a/config/README.md
+++ b/config/README.md
@@ -43,7 +43,15 @@ vector:
 
 5. If you want to tune `diagnose_build_failure`, add `config/diagnostic-parameters.yml`.
 
-6. Start the server with:
+6. If you want the optional Jenkins XML edit workflow for non-SCM-backed jobs, set:
+
+```yaml
+settings:
+  enable_job_xml_editing: true
+  job_xml_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
+```
+
+7. Start the server with:
 
 ```bash
 python -m jenkins_mcp_enterprise.server --config config/mcp-config.yml
@@ -93,10 +101,37 @@ Global behavior:
 - `auto_discover_instances`
 - `log_instance_switching`
 - `log_health_checks`
+- `enable_job_xml_editing`
+- `job_xml_workspace_dir`
+
+`enable_job_xml_editing` is `false` by default. When enabled, `get_job_definition` can download a Jenkins job `config.xml` into the local workspace directory, and the server registers `apply_job_xml_edit` so the edited XML can be uploaded back to Jenkins. This is intended for Jenkins-managed XML jobs and inline pipeline definitions, not SCM-backed Jenkinsfiles.
 
 ### `vector`
 
 Controls semantic search. If `disable_vector_search: true`, the `semantic_search` tool is not registered.
+
+## Tool Registration Notes
+
+The tool surface is mostly static, with two conditional tools:
+
+- `semantic_search` is registered only when vector search is enabled
+- `apply_job_xml_edit` is registered only when `settings.enable_job_xml_editing: true`
+
+The main always-on tool set includes:
+
+- `trigger_build`
+- `trigger_build_async`
+- `trigger_build_with_subs`
+- `get_jenkins_job_parameters`
+- `find_jobs`
+- `list_job_builds`
+- `get_build_info`
+- `get_job_definition`
+- `get_log_context`
+- `filter_errors_grep`
+- `ripgrep_search`
+- `navigate_log`
+- `diagnose_build_failure`
 
 ### `cache`
 

--- a/config/mcp-config.example.yml
+++ b/config/mcp-config.example.yml
@@ -77,10 +77,11 @@ settings:
   log_instance_switching: true
   log_health_checks: false
 
-  # Optional: allow downloading Jenkins job config XML locally and uploading
-  # a modified XML file back to Jenkins via MCP. Disabled by default.
-  enable_job_xml_editing: false
-  job_xml_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
+  # Optional: allow downloading Jenkins-managed job definitions locally and
+  # uploading validated edits back through MCP. Inline pipelines are staged as
+  # Groovy files; XML-managed jobs are staged as config.xml files.
+  enable_job_editing: false
+  job_edit_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
 
 # Vector Search Configuration
 vector:

--- a/config/mcp-config.example.yml
+++ b/config/mcp-config.example.yml
@@ -77,6 +77,11 @@ settings:
   log_instance_switching: true
   log_health_checks: false
 
+  # Optional: allow downloading Jenkins job config XML locally and uploading
+  # a modified XML file back to Jenkins via MCP. Disabled by default.
+  enable_job_xml_editing: false
+  job_xml_workspace_dir: "/tmp/mcp-jenkins/job-definitions"
+
 # Vector Search Configuration
 vector:
   disable_vector_search: false

--- a/jenkins_mcp_enterprise/jenkins/build_manager.py
+++ b/jenkins_mcp_enterprise/jenkins/build_manager.py
@@ -17,10 +17,43 @@ class BuildManager:
     def __init__(self, connection_manager: JenkinsConnectionManager):
         self.connection = connection_manager
 
+    def _call_client(self, operation_name: str, callback):
+        """Execute a Jenkins client operation, refreshing the client once if stale."""
+        try:
+            return callback(self.connection.client)
+        except Exception as e:
+            should_refresh = getattr(
+                self.connection, "should_refresh_on_error", lambda _error: False
+            )
+            if should_refresh(e):
+                logger.warning(
+                    "%s failed with a stale Jenkins session error; refreshing connection and retrying once: %s",
+                    operation_name,
+                    e,
+                )
+                self.connection.refresh_connection()
+                return callback(self.connection.client)
+            raise
+
+    def _is_missing_queue_item_error(self, error: Exception) -> bool:
+        """Return True when Jenkins no longer exposes the queue item."""
+        error_type = type(error).__name__.lower()
+        message = str(error).lower()
+        return (
+            "notfound" in error_type
+            or "404" in message
+            or "not found" in message
+            or "does not exist" in message
+            or "queue number" in message
+        )
+
     def get_next_build_number(self, job_name: str) -> int:
         """Get the next build number for a job"""
         try:
-            job_info = self.connection.client.get_job_info(job_name)
+            job_info = self._call_client(
+                f"Get next build number for {job_name}",
+                lambda client: client.get_job_info(job_name),
+            )
             return job_info["nextBuildNumber"]
         except Exception as e:
             raise JenkinsConnectionError(
@@ -42,8 +75,9 @@ class BuildManager:
             if token is not None:
                 build_kwargs["token"] = token
 
-            queue_item_number = self.connection.client.build_job(
-                job_name, **build_kwargs
+            queue_item_number = self._call_client(
+                f"Trigger build for {job_name}",
+                lambda client: client.build_job(job_name, **build_kwargs),
             )
 
             if not queue_item_number:
@@ -75,7 +109,10 @@ class BuildManager:
 
         while time.time() - start_time < timeout:
             try:
-                queue_item = self.connection.client.get_queue_item(queue_item_number)
+                queue_item = self._call_client(
+                    f"Poll queue item {queue_item_number} for {job_name}",
+                    lambda client: client.get_queue_item(queue_item_number),
+                )
 
                 if "executable" in queue_item and queue_item["executable"]:
                     build_number = queue_item["executable"]["number"]
@@ -85,7 +122,7 @@ class BuildManager:
                 time.sleep(2)
 
             except Exception as e:
-                if "NotFoundException" in str(type(e)):
+                if self._is_missing_queue_item_error(e):
                     # Queue item disappeared, try to find the build
                     return self._find_recent_build(job_name)
                 else:
@@ -101,7 +138,10 @@ class BuildManager:
     def _find_recent_build(self, job_name: str) -> int:
         """Find the most recent build for a job"""
         try:
-            job_info = self.connection.client.get_job_info(job_name)
+            job_info = self._call_client(
+                f"Find recent build for {job_name}",
+                lambda client: client.get_job_info(job_name),
+            )
             if job_info["lastBuild"]:
                 return job_info["lastBuild"]["number"]
             else:
@@ -114,8 +154,11 @@ class BuildManager:
     def get_build_info(self, job_name: str, build_number: int, depth: int = 1) -> Build:
         """Get information about a specific build"""
         try:
-            build_info = self.connection.client.get_build_info(
-                job_name, build_number, depth=depth
+            build_info = self._call_client(
+                f"Get build info for {job_name}#{build_number}",
+                lambda client: client.get_build_info(
+                    job_name, build_number, depth=depth
+                ),
             )
 
             # Determine status from build info
@@ -176,7 +219,10 @@ class BuildManager:
     def get_job_parameters(self, job_name: str) -> List[Dict[str, Any]]:
         """Get parameters definition for a job"""
         try:
-            job_info = self.connection.client.get_job_info(job_name)
+            job_info = self._call_client(
+                f"Get job parameters for {job_name}",
+                lambda client: client.get_job_info(job_name),
+            )
             parameters = []
 
             for action in job_info.get("actions", []):
@@ -203,7 +249,10 @@ class BuildManager:
     def cancel_build(self, job_name: str, build_number: int) -> bool:
         """Cancel a running build"""
         try:
-            self.connection.client.stop_build(job_name, build_number)
+            self._call_client(
+                f"Cancel build {job_name}#{build_number}",
+                lambda client: client.stop_build(job_name, build_number),
+            )
             logger.info(f"Cancelled build {job_name}#{build_number}")
             return True
         except Exception as e:

--- a/jenkins_mcp_enterprise/jenkins/connection_manager.py
+++ b/jenkins_mcp_enterprise/jenkins/connection_manager.py
@@ -48,6 +48,20 @@ class JenkinsConnectionManager:
             self.config.url,
         )
 
+    def refresh_connection(self) -> None:
+        """Recreate the Jenkins client/session after a stale-session style failure."""
+        logger.warning("Refreshing Jenkins connection for %s", self.config.url)
+        self._initialize_connection()
+
+    def should_refresh_on_error(self, error: Exception) -> bool:
+        """Return True when an error suggests the Jenkins client/session is stale."""
+        message = str(error).lower()
+        return (
+            "no valid crumb was included" in message
+            or ("403" in message and "forbidden" in message)
+            or "csrf" in message
+        )
+
     def _validate_connection(self) -> None:
         """Validate that Jenkins is reachable/auth is valid by calling a lightweight API."""
         try:

--- a/jenkins_mcp_enterprise/jenkins/jenkins_client.py
+++ b/jenkins_mcp_enterprise/jenkins/jenkins_client.py
@@ -154,6 +154,19 @@ class JenkinsClient:
         """Get job information (compatibility method)"""
         return self.connection.client.get_job_info(job_name)
 
+    def list_jobs(self) -> List[Dict[str, Any]]:
+        """List all jobs visible to the configured Jenkins account."""
+        return self.connection.client.get_all_jobs()
+
+    def get_job_config_xml(self, job_name: str) -> str:
+        """Download the Jenkins job config XML for a job."""
+        return self.connection.client.get_job_config(job_name)
+
+    def reconfig_job_xml(self, job_name: str, config_xml: str) -> bool:
+        """Upload a modified Jenkins job config XML for a job."""
+        self.connection.client.reconfig_job(job_name, config_xml)
+        return True
+
     def get_build_console_output(self, job_name: str, build_number: int) -> str:
         """Get console output as single string (compatibility method)"""
         lines = self.get_console_log(job_name, build_number)

--- a/jenkins_mcp_enterprise/server.py
+++ b/jenkins_mcp_enterprise/server.py
@@ -66,6 +66,47 @@ def create_server(
 def register_jenkins_resources(mcp: FastMCP, multi_jenkins_manager) -> None:
     """Register MCP resources for Jenkins URL to credentials mapping"""
 
+    @mcp.resource("jenkins://instances")
+    def jenkins_instances() -> dict:
+        """Lists configured Jenkins instances without leaking credentials."""
+        instances = []
+        for instance_id, config in multi_jenkins_manager.instances_config.items():
+            instances.append(
+                {
+                    "id": instance_id,
+                    "uri": f"jenkins://instances/{instance_id}",
+                    "url": config.url,
+                    "display_name": config.display_name or instance_id,
+                    "description": config.description or f"Jenkins instance: {config.url}",
+                    "has_credentials": bool(config.token),
+                }
+            )
+        return {
+            "instances": instances,
+            "total": len(instances),
+            "usage": "Use the per-instance resource URI for metadata or pass jenkins_url to tools.",
+        }
+
+    @mcp.resource("jenkins://instances/{instance_id}")
+    def jenkins_instance(instance_id: str) -> dict:
+        """Returns metadata for a single configured Jenkins instance."""
+        config = multi_jenkins_manager.instances_config.get(instance_id)
+        if not config:
+            return {
+                "instance_id": instance_id,
+                "status": "not_configured",
+                "message": f"No Jenkins instance configured for key '{instance_id}'",
+            }
+        return {
+            "instance_id": instance_id,
+            "status": "configured",
+            "uri": f"jenkins://instances/{instance_id}",
+            "url": config.url,
+            "display_name": config.display_name or instance_id,
+            "description": config.description or f"Jenkins instance: {config.url}",
+            "has_credentials": bool(config.token),
+        }
+
     @mcp.resource("jenkins://info")
     def jenkins_instances_info() -> dict:
         """Lists all available Jenkins instances with their URLs and descriptions"""

--- a/jenkins_mcp_enterprise/server.py
+++ b/jenkins_mcp_enterprise/server.py
@@ -77,7 +77,8 @@ def register_jenkins_resources(mcp: FastMCP, multi_jenkins_manager) -> None:
                     "uri": f"jenkins://instances/{instance_id}",
                     "url": config.url,
                     "display_name": config.display_name or instance_id,
-                    "description": config.description or f"Jenkins instance: {config.url}",
+                    "description": config.description
+                    or f"Jenkins instance: {config.url}",
                     "has_credentials": bool(config.token),
                 }
             )

--- a/jenkins_mcp_enterprise/tool_factory.py
+++ b/jenkins_mcp_enterprise/tool_factory.py
@@ -16,11 +16,13 @@ from typing import Dict
 from .base import Tool
 from .di_container import DIContainer
 from .tools.diagnostics import DiagnoseBuildFailureTool
+from .tools.jobs import ApplyJobXmlEditTool, FindJobsTool, GetJobDefinitionTool
 from .tools.jenkins_tools import GetJobParametersTool
 from .tools.logs import FilterErrorsTool, LogContextTool
 from .tools.ripgrep_tool import NavigateLogTool, RipgrepSearchTool
 from .tools.search import SemanticSearchTool
 from .tools.subbuilds import SubBuildTraversalTool
+from .tools.builds import GetBuildInfoTool, ListJobBuildsTool
 
 # Import all tool classes
 from .tools.trigger import AsyncBuildTool, TriggerBuildTool
@@ -77,6 +79,21 @@ class ToolFactory:
         )
         tools[get_params_tool.name] = get_params_tool
 
+        find_jobs_tool = FindJobsTool(
+            jenkins_client=jenkins_client, multi_jenkins_manager=multi_jenkins_manager
+        )
+        tools[find_jobs_tool.name] = find_jobs_tool
+
+        list_builds_tool = ListJobBuildsTool(
+            jenkins_client=jenkins_client, multi_jenkins_manager=multi_jenkins_manager
+        )
+        tools[list_builds_tool.name] = list_builds_tool
+
+        get_build_info_tool = GetBuildInfoTool(
+            jenkins_client=jenkins_client, multi_jenkins_manager=multi_jenkins_manager
+        )
+        tools[get_build_info_tool.name] = get_build_info_tool
+
         # Tools requiring JenkinsClient and CacheManager (now with multi-instance support)
         async_tool = AsyncBuildTool(
             jenkins_client=jenkins_client,
@@ -120,6 +137,25 @@ class ToolFactory:
             multi_jenkins_manager=multi_jenkins_manager,
         )
         tools[navigate_tool.name] = navigate_tool
+
+        get_job_definition_tool = GetJobDefinitionTool(
+            jenkins_client=jenkins_client,
+            cache_manager=cache_manager,
+            multi_jenkins_manager=multi_jenkins_manager,
+        )
+        tools[get_job_definition_tool.name] = get_job_definition_tool
+
+        if bool(
+            getattr(multi_jenkins_manager, "settings", {}).get(
+                "enable_job_xml_editing", False
+            )
+        ):
+            apply_job_xml_edit_tool = ApplyJobXmlEditTool(
+                jenkins_client=jenkins_client,
+                cache_manager=cache_manager,
+                multi_jenkins_manager=multi_jenkins_manager,
+            )
+            tools[apply_job_xml_edit_tool.name] = apply_job_xml_edit_tool
 
         # Tools requiring JenkinsClient, CacheManager, and VectorManager (now with multi-instance support)
         if not getattr(vector_manager, "vector_search_disabled", False):
@@ -172,8 +208,15 @@ class ToolFactory:
         Returns:
             The number of tools this factory creates
         """
-        count = 9
+        count = 13
         vector_manager = self.container.get_vector_manager()
         if not getattr(vector_manager, "vector_search_disabled", False):
+            count += 1
+        multi_jenkins_manager = self.container.get_multi_jenkins_manager()
+        if bool(
+            getattr(multi_jenkins_manager, "settings", {}).get(
+                "enable_job_xml_editing", False
+            )
+        ):
             count += 1
         return count

--- a/jenkins_mcp_enterprise/tool_factory.py
+++ b/jenkins_mcp_enterprise/tool_factory.py
@@ -16,7 +16,7 @@ from typing import Dict
 from .base import Tool
 from .di_container import DIContainer
 from .tools.diagnostics import DiagnoseBuildFailureTool
-from .tools.jobs import ApplyJobXmlEditTool, FindJobsTool, GetJobDefinitionTool
+from .tools.jobs import ApplyJobEditTool, FindJobsTool, GetJobDefinitionTool
 from .tools.jenkins_tools import GetJobParametersTool
 from .tools.logs import FilterErrorsTool, LogContextTool
 from .tools.ripgrep_tool import NavigateLogTool, RipgrepSearchTool
@@ -147,15 +147,18 @@ class ToolFactory:
 
         if bool(
             getattr(multi_jenkins_manager, "settings", {}).get(
-                "enable_job_xml_editing", False
+                "enable_job_editing",
+                getattr(multi_jenkins_manager, "settings", {}).get(
+                    "enable_job_xml_editing", False
+                ),
             )
         ):
-            apply_job_xml_edit_tool = ApplyJobXmlEditTool(
+            apply_job_edit_tool = ApplyJobEditTool(
                 jenkins_client=jenkins_client,
                 cache_manager=cache_manager,
                 multi_jenkins_manager=multi_jenkins_manager,
             )
-            tools[apply_job_xml_edit_tool.name] = apply_job_xml_edit_tool
+            tools[apply_job_edit_tool.name] = apply_job_edit_tool
 
         # Tools requiring JenkinsClient, CacheManager, and VectorManager (now with multi-instance support)
         if not getattr(vector_manager, "vector_search_disabled", False):
@@ -215,7 +218,10 @@ class ToolFactory:
         multi_jenkins_manager = self.container.get_multi_jenkins_manager()
         if bool(
             getattr(multi_jenkins_manager, "settings", {}).get(
-                "enable_job_xml_editing", False
+                "enable_job_editing",
+                getattr(multi_jenkins_manager, "settings", {}).get(
+                    "enable_job_xml_editing", False
+                ),
             )
         ):
             count += 1

--- a/jenkins_mcp_enterprise/tools/builds.py
+++ b/jenkins_mcp_enterprise/tools/builds.py
@@ -28,6 +28,8 @@ DEFAULT_LIST_TREE = (
 DEFAULT_LIST_COUNT = 25
 MAX_LIST_COUNT = 500
 MIN_LIST_COUNT = 1
+DEFAULT_BUILDS_BEFORE = 3
+DEFAULT_BUILDS_AFTER = 2
 
 
 def _clamp_count(value: int) -> int:
@@ -63,7 +65,9 @@ class ListJobBuildsTool(JenkinsOperationTool):
             "Returns recent builds for a Jenkins job with metadata "
             "(number, result, timestamp, duration, description, displayName, url), "
             "so callers can pick a specific build by criteria before calling "
-            "log-analysis tools. Queries a single Jenkins instance per call "
+            "log-analysis tools. Can also return a small window of builds around "
+            "a specific build number instead of the full recent list. Queries a "
+            "single Jenkins instance per call "
             "(resolved from `jenkins_url`); does not aggregate across configured "
             "instances. IMPORTANT: jenkins_url is required because jobs are "
             "load-balanced across multiple Jenkins servers."
@@ -96,6 +100,39 @@ class ListJobBuildsTool(JenkinsOperationTool):
                 required=False,
                 default="",
             ),
+            ParameterSpec(
+                "around_build_number",
+                int,
+                (
+                    "Optional build number to center a build window around. "
+                    "When provided, the response includes only nearby builds "
+                    "from the fetched set."
+                ),
+                required=False,
+                default=None,
+            ),
+            ParameterSpec(
+                "before",
+                int,
+                (
+                    "How many older builds to include before around_build_number "
+                    f"(default {DEFAULT_BUILDS_BEFORE}). Ignored unless "
+                    "around_build_number is provided."
+                ),
+                required=False,
+                default=DEFAULT_BUILDS_BEFORE,
+            ),
+            ParameterSpec(
+                "after",
+                int,
+                (
+                    "How many newer builds to include after around_build_number "
+                    f"(default {DEFAULT_BUILDS_AFTER}). Ignored unless "
+                    "around_build_number is provided."
+                ),
+                required=False,
+                default=DEFAULT_BUILDS_AFTER,
+            ),
         ]
 
     def _execute_impl(self, **kwargs) -> Dict[str, Any]:
@@ -103,6 +140,9 @@ class ListJobBuildsTool(JenkinsOperationTool):
         jenkins_url = kwargs["jenkins_url"]
         effective_count = _clamp_count(kwargs.get("count"))
         tree_override = (kwargs.get("tree") or "").strip()
+        around_build_number: Optional[int] = kwargs.get("around_build_number")
+        before = max(0, kwargs.get("before") or 0)
+        after = max(0, kwargs.get("after") or 0)
 
         # Compute the canonical echo up-front so every return path shows the
         # same job_name value. to_jenkins_api_path() normalizes internally,
@@ -123,6 +163,16 @@ class ListJobBuildsTool(JenkinsOperationTool):
         api_job_path = JobNameParser.to_jenkins_api_path(job_name)
         base_url = jenkins_client.config.url.rstrip("/")
         base_tree = tree_override if tree_override else DEFAULT_LIST_TREE
+        if around_build_number is not None and "number" not in base_tree:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "error": (
+                    "around_build_number requires build numbers in the selected "
+                    "tree. Include 'number' in the tree filter or omit the tree "
+                    "override."
+                ),
+            }
         tree_value = f"{base_tree}{{0,{effective_count}}}"
         api_url = f"{base_url}/{api_job_path}/api/json"
 
@@ -160,11 +210,40 @@ class ListJobBuildsTool(JenkinsOperationTool):
             }
 
         builds = payload.get("builds") or []
+        if around_build_number is not None:
+            match_index = next(
+                (
+                    idx
+                    for idx, build in enumerate(builds)
+                    if build.get("number") == around_build_number
+                ),
+                None,
+            )
+            if match_index is None:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "tree": tree_value,
+                    "requested_count": effective_count,
+                    "around_build_number": around_build_number,
+                    "error": (
+                        "around_build_number was not present in the fetched build "
+                        "set. Increase count or query a more recent build."
+                    ),
+                }
+
+            start = max(0, match_index - before)
+            end = min(len(builds), match_index + after + 1)
+            builds = builds[start:end]
+
         return {
             "job_name": normalized_job,
             "jenkins_url": jenkins_url,
             "tree": tree_value,
             "requested_count": effective_count,
+            "around_build_number": around_build_number,
+            "before": before,
+            "after": after,
             "returned_count": len(builds),
             "builds": builds,
         }

--- a/jenkins_mcp_enterprise/tools/common.py
+++ b/jenkins_mcp_enterprise/tools/common.py
@@ -97,6 +97,26 @@ class LogFetcher:
         self.cache_manager = cache_manager
         self.resolver = resolver
 
+    def _normalize_fetch_error(
+        self, job_name: str, build_number: int, jenkins_url: str, error: Exception
+    ) -> Dict[str, Any]:
+        message = str(error)
+        lower = message.lower()
+        if "404" in lower or "not found" in lower:
+            sanitized = (
+                "Build not found. Verify the job_name and build_number exist on the "
+                "selected Jenkins instance."
+            )
+        else:
+            sanitized = f"Failed to fetch log: {message}"
+
+        return {
+            "job_name": job_name,
+            "build_number": build_number,
+            "jenkins_url": jenkins_url,
+            "error": sanitized,
+        }
+
     def fetch_log(
         self, job_name: str, build_number: int, jenkins_url: str
     ) -> tuple[Optional[str], Optional[Dict[str, Any]]]:
@@ -119,12 +139,9 @@ class LogFetcher:
             log_path = self.cache_manager.fetch(jenkins_client, build_obj)
             return log_path, None
         except Exception as e:
-            return None, {
-                "job_name": job_name,
-                "build_number": build_number,
-                "jenkins_url": jenkins_url,
-                "error": f"Failed to fetch log: {str(e)}",
-            }
+            return None, self._normalize_fetch_error(
+                job_name, build_number, jenkins_url, e
+            )
 
 
 from ..utils import find_ripgrep

--- a/jenkins_mcp_enterprise/tools/diagnostics.py
+++ b/jenkins_mcp_enterprise/tools/diagnostics.py
@@ -25,6 +25,7 @@ Without these plugins, sub-build discovery will be limited to log parsing only.
 """
 
 import concurrent.futures
+import copy
 import io
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -33,6 +34,11 @@ import jenkins
 from ..base import Build, ParameterSpec, SubBuild
 from ..cache_manager import CacheManager
 from ..diagnostic_config.diagnostic_config import get_diagnostic_config
+from ..jenkins.build_tree import (
+    annotate_build_tree,
+    flatten_build_tree,
+    prune_build_tree_to_failure_paths,
+)
 from ..jenkins.jenkins_client import JenkinsClient
 from ..jenkins.job_name_utils import JobNameParser
 from ..logging_config import get_component_logger
@@ -176,6 +182,15 @@ class DiagnoseBuildFailureTool(JenkinsOperationTool):
 
             # Recursively build children for this child
             self._build_hierarchical_structure(sub_builds, child_node)
+
+    def _strip_parent_fields_from_tree(self, node: Dict[str, Any]) -> Dict[str, Any]:
+        """Remove parent pointer fields from output tree nodes to reduce payload size."""
+        node.pop("parent_job_name", None)
+        node.pop("parent_build_number", None)
+        for child in node.get("children", []) or []:
+            if isinstance(child, dict):
+                self._strip_parent_fields_from_tree(child)
+        return node
 
     def _flatten_build_tree(self, build_node: Dict[str, Any]) -> List[Dict[str, Any]]:
         """Flattens the hierarchical build tree for analysis purposes."""
@@ -372,10 +387,12 @@ class DiagnoseBuildFailureTool(JenkinsOperationTool):
             "vector_indexing_status": "NOT_ATTEMPTED",
             "heuristic_findings": [],
             "semantic_search_highlights": [],
+            "error_analysis": {"errors": [], "semantic_highlights": []},
+            "sub_builds": [],
+            "sub_builds_count": 0,
             "errors": [],
             "sub_build_information": {"build_tree": {}, "guidance": "", "errors": []},
             "build_summary": "",
-            "error_analysis": [],
             "recommendations": [],
             "context_stats": {
                 "total_tokens": 0,
@@ -448,10 +465,37 @@ class DiagnoseBuildFailureTool(JenkinsOperationTool):
 
         # Get sub-build information
         sub_build_info = self._get_sub_build_information(build, jenkins_client)
-        result["sub_build_information"] = sub_build_info
+        build_tree = sub_build_info.get("build_tree", {}) or {}
+        if build_tree:
+            annotate_build_tree(build_tree)
+            if params["skip_successful_builds"]:
+                analysis_tree = prune_build_tree_to_failure_paths(build_tree)
+            else:
+                analysis_tree = build_tree
+            hierarchy_dicts = flatten_build_tree(analysis_tree)
+            output_tree = self._strip_parent_fields_from_tree(
+                copy.deepcopy(analysis_tree)
+            )
+            sub_build_info["build_tree"] = output_tree
+            result["sub_builds"] = [
+                {
+                    "job_name": node["job_name"],
+                    "build_number": node["build_number"],
+                    "status": node.get("status", "UNKNOWN"),
+                    "url": node.get("url"),
+                    "depth": int(node.get("depth", 0) or 0),
+                    "failed": bool(node.get("failed", False)),
+                    "parent_job_name": node.get("parent_job_name"),
+                    "parent_build_number": node.get("parent_build_number"),
+                }
+                for node in hierarchy_dicts
+                if int(node.get("depth", 0) or 0) != 0
+            ]
+            result["sub_builds_count"] = len(result["sub_builds"])
+        else:
+            hierarchy_dicts = []
 
-        # Build hierarchy for analysis - extract all builds from the tree
-        hierarchy_dicts = self._flatten_build_tree(sub_build_info["build_tree"])
+        result["sub_build_information"] = sub_build_info
 
         # Convert hierarchy dictionaries to Build objects for processing
         hierarchy_builds = []
@@ -481,10 +525,18 @@ class DiagnoseBuildFailureTool(JenkinsOperationTool):
             result["build_summary"] = self._generate_build_summary(
                 build, hierarchy_builds
             )
-            result["semantic_search_highlights"] = self._generate_semantic_highlights(
+            semantic_highlights = self._generate_semantic_highlights(
                 log_chunks, self.vector_manager, build
             )
-            result["error_analysis"] = self._extract_key_failure_patterns(log_chunks)
+            result["semantic_search_highlights"] = semantic_highlights
+            result["error_analysis"] = {
+                "errors": self._extract_error_entries(
+                    log_chunks,
+                    root_build=build,
+                    exclude_root=bool(result["sub_builds"]),
+                ),
+                "semantic_highlights": semantic_highlights,
+            }
             result["recommendations"] = self._generate_recommendations(
                 hierarchy_builds, log_chunks
             )
@@ -618,6 +670,66 @@ Primary Failure Points:
                 patterns.append(pattern)
 
         return patterns[:max_patterns]
+
+    def _extract_error_entries(
+        self,
+        chunks: List,
+        *,
+        root_build: Optional[Build] = None,
+        exclude_root: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Return structured, size-bounded error entries for MCP responses."""
+        entries: List[Dict[str, Any]] = []
+        failure_patterns = self.config.get_failure_patterns()
+        max_entries = min(
+            10,
+            self.config.config.failure_patterns.max_fallback_patterns,
+        )
+        max_match_text = 600
+        max_context = 2500
+
+        for chunk in chunks:
+            if len(entries) >= max_entries:
+                break
+
+            if (
+                exclude_root
+                and root_build is not None
+                and chunk.build.job_name == root_build.job_name
+                and chunk.build.build_number == root_build.build_number
+            ):
+                continue
+
+            lines = chunk.content.splitlines()
+            match_line = None
+            priority_groups = [
+                ["error"],
+                ["exception"],
+                ["failed", "failure"],
+                failure_patterns,
+            ]
+            for group in priority_groups:
+                for line in lines:
+                    lowered = line.lower()
+                    if any(pattern in lowered for pattern in group):
+                        match_line = line.strip()
+                        break
+                if match_line:
+                    break
+
+            if not match_line:
+                continue
+
+            entries.append(
+                {
+                    "job_name": chunk.build.job_name,
+                    "build_number": chunk.build.build_number,
+                    "match_text": match_line[:max_match_text],
+                    "context": chunk.content[:max_context],
+                }
+            )
+
+        return entries
 
     def _generate_recommendations(
         self, failure_hierarchy: List[Build], chunks: List

--- a/jenkins_mcp_enterprise/tools/jobs.py
+++ b/jenkins_mcp_enterprise/tools/jobs.py
@@ -17,6 +17,9 @@ from .common import CommonParameters
 DEFAULT_FIND_LIMIT = 25
 MAX_FIND_LIMIT = 200
 DEFAULT_INLINE_SCRIPT_CHARS = 20000
+INLINE_PIPELINE_SCRIPT_FILENAME = "pipeline.groovy"
+JOB_XML_FILENAME = "config.xml"
+SCRIPT_COMPILE_DESCRIPTOR = "org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition"
 
 
 def _sanitize_path_segment(value: str) -> str:
@@ -28,28 +31,38 @@ def _clamp_find_limit(value: int) -> int:
     return max(1, min(value, MAX_FIND_LIMIT))
 
 
-def _xml_editing_enabled(multi_jenkins_manager) -> bool:
+def _job_editing_enabled(multi_jenkins_manager) -> bool:
     if not multi_jenkins_manager:
         return False
-    return bool(multi_jenkins_manager.settings.get("enable_job_xml_editing", False))
+    settings = getattr(multi_jenkins_manager, "settings", {}) or {}
+    return bool(
+        settings.get(
+            "enable_job_editing", settings.get("enable_job_xml_editing", False)
+        )
+    )
 
 
-def _xml_workspace_root(cache_manager: CacheManager, multi_jenkins_manager) -> Path:
+def _job_edit_workspace_root(
+    cache_manager: CacheManager, multi_jenkins_manager
+) -> Path:
     override = None
     if multi_jenkins_manager:
-        override = multi_jenkins_manager.settings.get("job_xml_workspace_dir")
+        settings = getattr(multi_jenkins_manager, "settings", {}) or {}
+        override = settings.get("job_edit_workspace_dir") or settings.get(
+            "job_xml_workspace_dir"
+        )
     if override:
         return Path(override).expanduser()
     return cache_manager.config.base_dir / "job-definitions"
 
 
-def _job_xml_path(
+def _job_edit_dir(
     cache_manager: CacheManager,
     multi_jenkins_manager,
     instance_id: Optional[str],
     normalized_job_name: str,
 ) -> Path:
-    workspace_root = _xml_workspace_root(cache_manager, multi_jenkins_manager)
+    workspace_root = _job_edit_workspace_root(cache_manager, multi_jenkins_manager)
     instance_segment = _sanitize_path_segment(instance_id or "default")
     job_parts = [
         _sanitize_path_segment(part)
@@ -58,7 +71,41 @@ def _job_xml_path(
     ]
     if not job_parts:
         job_parts = ["unnamed-job"]
-    return workspace_root / instance_segment / Path(*job_parts) / "config.xml"
+    return workspace_root / instance_segment / Path(*job_parts)
+
+
+def _job_xml_path(
+    cache_manager: CacheManager,
+    multi_jenkins_manager,
+    instance_id: Optional[str],
+    normalized_job_name: str,
+) -> Path:
+    return (
+        _job_edit_dir(
+            cache_manager,
+            multi_jenkins_manager,
+            instance_id,
+            normalized_job_name,
+        )
+        / JOB_XML_FILENAME
+    )
+
+
+def _job_inline_script_path(
+    cache_manager: CacheManager,
+    multi_jenkins_manager,
+    instance_id: Optional[str],
+    normalized_job_name: str,
+) -> Path:
+    return (
+        _job_edit_dir(
+            cache_manager,
+            multi_jenkins_manager,
+            instance_id,
+            normalized_job_name,
+        )
+        / INLINE_PIPELINE_SCRIPT_FILENAME
+    )
 
 
 def _extract_first_present(mapping: Dict[str, Any], *keys: str) -> Optional[Any]:
@@ -131,6 +178,14 @@ def _xml_text(node: Optional[ET.Element]) -> Optional[str]:
     return text or None
 
 
+def _classify_inline_pipeline_style(inline_script: Optional[str]) -> Optional[str]:
+    if not inline_script:
+        return None
+    return (
+        "declarative" if inline_script.lstrip().startswith("pipeline") else "scripted"
+    )
+
+
 def _parse_job_definition_xml(xml_text: str) -> Dict[str, Any]:
     """Extract pipeline definition details directly from Jenkins job XML."""
     root = ET.fromstring(xml_text)
@@ -165,12 +220,159 @@ def _parse_job_definition_xml(xml_text: str) -> Dict[str, Any]:
         result["repo_url"] = remote_urls[0] if remote_urls else None
         result["branch_specs"] = branch_specs
     elif definition_class and "CpsFlowDefinition" in definition_class:
+        inline_script = _xml_text(definition.find("script"))
         result["definition_type"] = "inline_pipeline"
-        result["inline_script"] = _xml_text(definition.find("script"))
+        result["inline_script"] = inline_script
+        result["pipeline_style"] = _classify_inline_pipeline_style(inline_script)
     elif root.tag.endswith("WorkflowMultiBranchProject"):
         result["definition_type"] = "multibranch_pipeline"
 
     return result
+
+
+def _build_script_compile_url(jenkins_client: JenkinsClient, job_name: str) -> str:
+    api_job_path = JobNameParser.to_jenkins_api_path(job_name)
+    base_url = jenkins_client.config.url.rstrip("/")
+    return (
+        f"{base_url}/{api_job_path}/descriptorByName/"
+        f"{SCRIPT_COMPILE_DESCRIPTOR}/checkScriptCompile"
+    )
+
+
+def _build_declarative_validation_url(jenkins_client: JenkinsClient) -> str:
+    return (
+        f"{jenkins_client.config.url.rstrip('/')}/pipeline-model-converter/"
+        "validateJenkinsfile"
+    )
+
+
+def _jenkins_post_json(
+    jenkins_client: JenkinsClient, url: str, data: Dict[str, str]
+) -> Any:
+    request = requests.Request("POST", url, data=data)
+    response = jenkins_client.connection.client.jenkins_request(request)
+    return response.json()
+
+
+def _collect_validation_errors(payload: Any) -> List[str]:
+    errors: List[str] = []
+    if isinstance(payload, dict):
+        nested_data = payload.get("data")
+        if isinstance(nested_data, dict):
+            errors.extend(_collect_validation_errors(nested_data))
+            message = payload.get("message") or payload.get("error")
+            if message:
+                errors.append(str(message))
+            return errors
+
+        status = payload.get("status")
+        result = payload.get("result")
+        if status in {"success", "ok"} and result in {None, "success"}:
+            return []
+        if result == "success":
+            return []
+        nested_errors = payload.get("errors")
+        if isinstance(nested_errors, list):
+            for entry in nested_errors:
+                if isinstance(entry, dict):
+                    message = entry.get("message") or entry.get("error")
+                    if message:
+                        errors.append(str(message))
+                elif entry:
+                    errors.append(str(entry))
+        message = payload.get("message") or payload.get("error")
+        if message:
+            errors.append(str(message))
+    elif isinstance(payload, list):
+        for entry in payload:
+            if isinstance(entry, dict):
+                if entry.get("status") == "success":
+                    continue
+                message = entry.get("message") or entry.get("error")
+                if message:
+                    errors.append(str(message))
+            elif entry:
+                errors.append(str(entry))
+    elif payload:
+        errors.append(str(payload))
+    return errors
+
+
+def _validate_declarative_pipeline_script(
+    jenkins_client: JenkinsClient, script_text: str
+) -> Dict[str, Any]:
+    url = _build_declarative_validation_url(jenkins_client)
+    try:
+        payload = _jenkins_post_json(jenkins_client, url, {"jenkinsfile": script_text})
+    except Exception as e:
+        return {
+            "valid": False,
+            "validator": "declarative",
+            "pipeline_style": "declarative",
+            "errors": [f"Declarative pipeline validation request failed: {str(e)}"],
+        }
+
+    errors = _collect_validation_errors(payload)
+    return {
+        "valid": not errors,
+        "validator": "declarative",
+        "pipeline_style": "declarative",
+        "errors": errors,
+    }
+
+
+def _validate_scripted_pipeline_script(
+    jenkins_client: JenkinsClient, job_name: str, script_text: str
+) -> Dict[str, Any]:
+    url = _build_script_compile_url(jenkins_client, job_name)
+    try:
+        payload = _jenkins_post_json(jenkins_client, url, {"value": script_text})
+    except Exception as e:
+        return {
+            "valid": False,
+            "validator": "script_compile",
+            "pipeline_style": "scripted",
+            "errors": [f"Scripted pipeline compile check failed: {str(e)}"],
+        }
+
+    errors = _collect_validation_errors(payload)
+    return {
+        "valid": not errors,
+        "validator": "script_compile",
+        "pipeline_style": "scripted",
+        "errors": errors,
+    }
+
+
+def _validate_pipeline_script(
+    jenkins_client: JenkinsClient,
+    job_name: str,
+    script_text: str,
+    pipeline_style: Optional[str] = None,
+) -> Dict[str, Any]:
+    effective_style = pipeline_style or _classify_inline_pipeline_style(script_text)
+    if effective_style == "declarative":
+        return _validate_declarative_pipeline_script(jenkins_client, script_text)
+    return _validate_scripted_pipeline_script(jenkins_client, job_name, script_text)
+
+
+def _replace_inline_pipeline_script(config_xml_text: str, script_text: str) -> str:
+    root = ET.fromstring(config_xml_text)
+    definition = root.find("definition")
+    if definition is None:
+        raise ValueError("Jenkins job XML is missing a <definition> node.")
+
+    definition_class = definition.get("class") or ""
+    if "CpsFlowDefinition" not in definition_class:
+        raise ValueError(
+            "Jenkins job XML does not contain an inline pipeline definition to edit."
+        )
+
+    script_node = definition.find("script")
+    if script_node is None:
+        script_node = ET.SubElement(definition, "script")
+    script_node.text = script_text
+    return ET.tostring(root, encoding="unicode")
 
 
 class FindJobsTool(JenkinsOperationTool):
@@ -219,7 +421,7 @@ class FindJobsTool(JenkinsOperationTool):
             ParameterSpec(
                 "folder",
                 str,
-                "Optional folder/job path prefix to constrain the search (for example 'team-a/services').",
+                "Optional folder/job path prefix to constrain the search (for example team-a/services).",
                 required=False,
                 default="",
             ),
@@ -300,7 +502,7 @@ class FindJobsTool(JenkinsOperationTool):
 
 
 class GetJobDefinitionTool(JenkinsOperationTool):
-    """Inspect a Jenkins job definition and optionally stage config XML for editing."""
+    """Inspect a Jenkins job definition and optionally stage it for editing."""
 
     def __init__(
         self,
@@ -323,10 +525,10 @@ class GetJobDefinitionTool(JenkinsOperationTool):
         return (
             "Inspects how a Jenkins job is defined. For SCM-backed pipelines, it "
             "returns source-control location details such as repository URL, branch "
-            "spec, and Jenkinsfile/script path. For inline or XML-backed jobs, it "
-            "returns the inline script when present and, if server-side XML editing "
-            "is enabled, downloads the job config XML to a local workspace path and "
-            "returns instructions for patching and re-uploading it."
+            "spec, and Jenkinsfile/script path. For Jenkins-managed jobs, it returns "
+            "inline script text when present and, if server-side job editing is "
+            "enabled, stages either a local Groovy file or job config XML for edit "
+            "and re-upload."
         )
 
     @property
@@ -405,9 +607,10 @@ class GetJobDefinitionTool(JenkinsOperationTool):
         script_path = (
             definition.get("scriptPath") if isinstance(definition, dict) else None
         )
-        inline_script = (
+        full_inline_script = (
             definition.get("script") if isinstance(definition, dict) else None
         )
+        pipeline_style = _classify_inline_pipeline_style(full_inline_script)
 
         definition_type = "job_config_xml"
         if "CpsScmFlowDefinition" in definition_class:
@@ -424,18 +627,19 @@ class GetJobDefinitionTool(JenkinsOperationTool):
             script_path = script_path or mb_script_path
 
         config_xml_text = None
-        xml_edit_enabled = _xml_editing_enabled(self.multi_jenkins_manager)
+        job_edit_enabled = _job_editing_enabled(self.multi_jenkins_manager)
         needs_xml_fallback = (
             not definition_class
             or (
                 definition_type in {"job_config_xml", "multibranch_pipeline"}
                 and not repo_url
-                and not inline_script
+                and not full_inline_script
                 and not script_path
             )
             or (definition_type == "scm_pipeline" and (not repo_url or not script_path))
+            or definition_type == "inline_pipeline"
         )
-        if needs_xml_fallback or xml_edit_enabled:
+        if needs_xml_fallback or job_edit_enabled:
             try:
                 config_xml_text = jenkins_client.get_job_config_xml(job_name)
             except Exception:
@@ -448,8 +652,10 @@ class GetJobDefinitionTool(JenkinsOperationTool):
             repo_url = repo_url or parsed_xml.get("repo_url")
             branch_specs = branch_specs or parsed_xml.get("branch_specs") or []
             script_path = script_path or parsed_xml.get("script_path")
-            inline_script = inline_script or parsed_xml.get("inline_script")
+            full_inline_script = full_inline_script or parsed_xml.get("inline_script")
+            pipeline_style = pipeline_style or parsed_xml.get("pipeline_style")
 
+        inline_script = full_inline_script
         inline_script_truncated = False
         if inline_script and max_inline_script_chars:
             if len(inline_script) > max_inline_script_chars:
@@ -458,15 +664,47 @@ class GetJobDefinitionTool(JenkinsOperationTool):
         elif max_inline_script_chars == 0:
             inline_script = None
 
-        xml_edit_supported = definition_type != "scm_pipeline"
-        local_xml_path = None
+        edit_supported = False
+        edit_mode = None
+        local_edit_path = None
         edit_instructions = None
 
-        if xml_edit_enabled and xml_edit_supported:
+        if definition_type in {"scm_pipeline", "multibranch_pipeline"}:
+            edit_instructions = (
+                "This job is SCM-backed. Modify the Jenkinsfile/script in source "
+                "control at the returned repository/path instead of editing it "
+                "through Jenkins MCP."
+            )
+        elif not job_edit_enabled:
+            edit_instructions = (
+                "Server-side job editing is disabled. To enable it, set "
+                "`settings.enable_job_editing: true` in the MCP config. The older "
+                "`settings.enable_job_xml_editing` alias is still accepted."
+            )
+        elif definition_type == "inline_pipeline" and full_inline_script is not None:
             try:
-                xml_text = config_xml_text or jenkins_client.get_job_config_xml(
-                    job_name
+                script_path_local = _job_inline_script_path(
+                    self.cache_manager,
+                    self.multi_jenkins_manager,
+                    instance_id,
+                    normalized_job,
                 )
+                script_path_local.parent.mkdir(parents=True, exist_ok=True)
+                script_path_local.write_text(full_inline_script, encoding="utf-8")
+                edit_supported = True
+                edit_mode = "inline_pipeline_script"
+                local_edit_path = str(script_path_local)
+                edit_instructions = (
+                    "Inline pipeline script was downloaded locally as Groovy. Modify "
+                    "that file with local patch/edit tools, then call "
+                    "`apply_job_edit` with the same `job_name`, `jenkins_url`, and "
+                    "this `local_edit_path` to validate and upload the updated "
+                    "pipeline definition back to Jenkins."
+                )
+            except Exception as e:
+                edit_instructions = f"Job editing is enabled, but inline script staging failed: {str(e)}"
+        elif config_xml_text:
+            try:
                 xml_path = _job_xml_path(
                     self.cache_manager,
                     self.multi_jenkins_manager,
@@ -474,28 +712,25 @@ class GetJobDefinitionTool(JenkinsOperationTool):
                     normalized_job,
                 )
                 xml_path.parent.mkdir(parents=True, exist_ok=True)
-                xml_path.write_text(xml_text, encoding="utf-8")
-                local_xml_path = str(xml_path)
+                xml_path.write_text(config_xml_text, encoding="utf-8")
+                edit_supported = True
+                edit_mode = "job_config_xml"
+                local_edit_path = str(xml_path)
                 edit_instructions = (
-                    "Jenkins job XML was downloaded locally. Modify that file with "
-                    "local patch/edit tools, then call `apply_job_xml_edit` with "
-                    "the same `job_name`, `jenkins_url`, and this `local_xml_path` "
-                    "to upload the edited config back to Jenkins."
+                    "Jenkins job config XML was downloaded locally. Modify that file "
+                    "with local patch/edit tools, then call `apply_job_edit` with "
+                    "the same `job_name`, `jenkins_url`, and this `local_edit_path` "
+                    "to validate and upload the edited job definition back to "
+                    "Jenkins."
                 )
             except Exception as e:
                 edit_instructions = (
-                    f"XML editing is enabled, but XML download failed: {str(e)}"
+                    f"Job editing is enabled, but XML staging failed: {str(e)}"
                 )
-        elif definition_type == "scm_pipeline":
-            edit_instructions = (
-                "This job is SCM-backed. Modify the Jenkinsfile/script in source "
-                "control at the returned repository/path instead of editing Jenkins "
-                "job XML."
-            )
         else:
             edit_instructions = (
-                "Server-side XML editing is disabled. To enable it, set "
-                "`settings.enable_job_xml_editing: true` in the MCP config."
+                "Job editing is enabled, but this job definition could not be staged "
+                "locally from Jenkins."
             )
 
         return {
@@ -505,6 +740,7 @@ class GetJobDefinitionTool(JenkinsOperationTool):
             "job_type": payload.get("_class"),
             "definition_type": definition_type,
             "definition_class": definition_class or None,
+            "pipeline_style": pipeline_style,
             "description": payload.get("description"),
             "url": payload.get("url"),
             "disabled": payload.get("disabled"),
@@ -515,18 +751,17 @@ class GetJobDefinitionTool(JenkinsOperationTool):
             },
             "inline_script": inline_script,
             "inline_script_truncated": inline_script_truncated,
-            "xml_editing_enabled": xml_edit_enabled,
-            "xml_editing_supported": xml_edit_supported,
-            "local_xml_path": local_xml_path,
-            "edit_upload_tool": (
-                "apply_job_xml_edit" if xml_edit_enabled and local_xml_path else None
-            ),
+            "job_editing_enabled": job_edit_enabled,
+            "edit_supported": edit_supported,
+            "edit_mode": edit_mode,
+            "local_edit_path": local_edit_path,
+            "edit_upload_tool": "apply_job_edit" if local_edit_path else None,
             "edit_instructions": edit_instructions,
         }
 
 
-class ApplyJobXmlEditTool(JenkinsOperationTool):
-    """Upload a locally edited Jenkins job config XML back to Jenkins."""
+class ApplyJobEditTool(JenkinsOperationTool):
+    """Upload a locally edited Jenkins job definition back to Jenkins."""
 
     def __init__(
         self,
@@ -542,14 +777,16 @@ class ApplyJobXmlEditTool(JenkinsOperationTool):
 
     @property
     def name(self) -> str:
-        return "apply_job_xml_edit"
+        return "apply_job_edit"
 
     @property
     def description(self) -> str:
         return (
-            "Uploads a locally edited Jenkins job config XML back to Jenkins. This "
-            "tool is intended for XML files previously downloaded by "
-            "`get_job_definition` when server-side XML editing is enabled."
+            "Uploads a locally edited Jenkins job definition back to Jenkins. This "
+            "tool accepts either a Groovy file previously staged for an inline "
+            "pipeline or a Jenkins config XML file previously staged by "
+            "`get_job_definition`, validates pipeline definitions with Jenkins when "
+            "applicable, and then applies the update."
         )
 
     @property
@@ -558,9 +795,9 @@ class ApplyJobXmlEditTool(JenkinsOperationTool):
             CommonParameters.job_name_param(),
             CommonParameters.jenkins_url_param(),
             ParameterSpec(
-                "local_xml_path",
+                "local_edit_path",
                 str,
-                "Absolute path to the locally edited Jenkins config XML file downloaded by get_job_definition.",
+                "Absolute path to the locally edited Groovy or Jenkins config XML file downloaded by get_job_definition.",
                 required=True,
             ),
         ]
@@ -568,17 +805,19 @@ class ApplyJobXmlEditTool(JenkinsOperationTool):
     def _execute_impl(self, **kwargs) -> Dict[str, Any]:
         job_name = kwargs["job_name"]
         jenkins_url = kwargs["jenkins_url"]
-        local_xml_path = kwargs["local_xml_path"]
+        local_edit_path = kwargs["local_edit_path"]
         normalized_job = JobNameParser.normalize_job_name(job_name)
 
-        if not _xml_editing_enabled(self.multi_jenkins_manager):
+        if not _job_editing_enabled(self.multi_jenkins_manager):
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "local_xml_path": local_xml_path,
+                "local_edit_path": local_edit_path,
                 "error": (
-                    "Server-side XML editing is disabled. Enable "
-                    "`settings.enable_job_xml_editing: true` to use this tool."
+                    "Server-side job editing is disabled. Enable "
+                    "`settings.enable_job_editing: true` to use this tool. The "
+                    "older `settings.enable_job_xml_editing` alias is also "
+                    "accepted."
                 ),
             }
 
@@ -589,25 +828,25 @@ class ApplyJobXmlEditTool(JenkinsOperationTool):
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "local_xml_path": local_xml_path,
+                "local_edit_path": local_edit_path,
                 "error": f"Jenkins instance resolution failed: {str(e)}",
                 "instructions": self.get_instance_instructions(),
             }
 
-        workspace_root = _xml_workspace_root(
+        workspace_root = _job_edit_workspace_root(
             self.cache_manager, self.multi_jenkins_manager
         ).resolve()
-        candidate_path = Path(local_xml_path).expanduser().resolve()
+        candidate_path = Path(local_edit_path).expanduser().resolve()
         try:
             candidate_path.relative_to(workspace_root)
         except ValueError:
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "local_xml_path": local_xml_path,
+                "local_edit_path": local_edit_path,
                 "error": (
-                    "local_xml_path must be inside the configured Jenkins XML "
-                    "workspace directory returned by get_job_definition."
+                    "local_edit_path must be inside the configured Jenkins job "
+                    "edit workspace directory returned by get_job_definition."
                 ),
             }
 
@@ -615,33 +854,145 @@ class ApplyJobXmlEditTool(JenkinsOperationTool):
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "local_xml_path": local_xml_path,
-                "error": "local_xml_path does not exist.",
+                "local_edit_path": local_edit_path,
+                "error": "local_edit_path does not exist.",
             }
 
-        if candidate_path.suffix.lower() != ".xml":
+        expected_script_path = _job_inline_script_path(
+            self.cache_manager,
+            self.multi_jenkins_manager,
+            instance_id,
+            normalized_job,
+        ).resolve()
+        expected_xml_path = _job_xml_path(
+            self.cache_manager,
+            self.multi_jenkins_manager,
+            instance_id,
+            normalized_job,
+        ).resolve()
+
+        edit_mode = None
+        if candidate_path == expected_script_path:
+            edit_mode = "inline_pipeline_script"
+        elif candidate_path == expected_xml_path:
+            edit_mode = "job_config_xml"
+        else:
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "local_xml_path": local_xml_path,
-                "error": "local_xml_path must point to an XML file.",
+                "local_edit_path": local_edit_path,
+                "error": (
+                    "local_edit_path does not match the expected staged edit file for "
+                    "this job and Jenkins instance. Re-run get_job_definition for the "
+                    "same job and use the returned local_edit_path exactly."
+                ),
             }
 
         try:
-            xml_text = candidate_path.read_text(encoding="utf-8")
-            jenkins_client.reconfig_job_xml(job_name, xml_text)
+            edited_text = candidate_path.read_text(encoding="utf-8")
         except Exception as e:
             return {
                 "job_name": normalized_job,
                 "jenkins_url": jenkins_url,
-                "local_xml_path": local_xml_path,
-                "error": f"Failed to upload edited Jenkins job XML: {str(e)}",
+                "local_edit_path": local_edit_path,
+                "error": f"Failed to read local edit file: {str(e)}",
+            }
+
+        validation = None
+        xml_to_upload = None
+
+        if edit_mode == "inline_pipeline_script":
+            validation = _validate_pipeline_script(
+                jenkins_client,
+                job_name,
+                edited_text,
+            )
+            if not validation["valid"]:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "local_edit_path": str(candidate_path),
+                    "edit_mode": edit_mode,
+                    "validation": validation,
+                    "error": "Jenkins rejected the edited inline pipeline script.",
+                }
+
+            try:
+                current_xml = jenkins_client.get_job_config_xml(job_name)
+                xml_to_upload = _replace_inline_pipeline_script(
+                    current_xml, edited_text
+                )
+            except Exception as e:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "local_edit_path": str(candidate_path),
+                    "edit_mode": edit_mode,
+                    "error": f"Failed to rebuild Jenkins job XML from the edited script: {str(e)}",
+                }
+        else:
+            try:
+                ET.fromstring(edited_text)
+            except ET.ParseError as e:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "local_edit_path": str(candidate_path),
+                    "edit_mode": edit_mode,
+                    "error": f"Edited Jenkins job XML is not well-formed: {str(e)}",
+                }
+
+            parsed_xml = _parse_job_definition_xml(edited_text)
+            definition_type = parsed_xml.get("definition_type")
+            if definition_type in {"scm_pipeline", "multibranch_pipeline"}:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "local_edit_path": str(candidate_path),
+                    "edit_mode": edit_mode,
+                    "error": (
+                        "SCM-backed Jenkins pipeline definitions must be edited in "
+                        "source control, not uploaded through apply_job_edit."
+                    ),
+                }
+
+            inline_script = parsed_xml.get("inline_script")
+            if inline_script:
+                validation = _validate_pipeline_script(
+                    jenkins_client,
+                    job_name,
+                    inline_script,
+                    pipeline_style=parsed_xml.get("pipeline_style"),
+                )
+                if not validation["valid"]:
+                    return {
+                        "job_name": normalized_job,
+                        "jenkins_url": jenkins_url,
+                        "local_edit_path": str(candidate_path),
+                        "edit_mode": edit_mode,
+                        "validation": validation,
+                        "error": "Jenkins rejected the pipeline definition embedded in the edited job XML.",
+                    }
+
+            xml_to_upload = edited_text
+
+        try:
+            jenkins_client.reconfig_job_xml(job_name, xml_to_upload)
+        except Exception as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_edit_path": str(candidate_path),
+                "edit_mode": edit_mode,
+                "error": f"Failed to upload edited Jenkins job definition: {str(e)}",
             }
 
         return {
             "job_name": normalized_job,
             "jenkins_url": jenkins_url,
-            "local_xml_path": str(candidate_path),
+            "local_edit_path": str(candidate_path),
+            "edit_mode": edit_mode,
             "updated": True,
-            "message": "Uploaded edited Jenkins job XML back to Jenkins.",
+            "validation": validation,
+            "message": "Validated and uploaded the edited Jenkins job definition back to Jenkins.",
         }

--- a/jenkins_mcp_enterprise/tools/jobs.py
+++ b/jenkins_mcp_enterprise/tools/jobs.py
@@ -150,13 +150,16 @@ def _parse_job_definition_xml(xml_text: str) -> Dict[str, Any]:
         remote_urls = [
             text
             for text in (
-                _xml_text(node) for node in definition.findall(".//userRemoteConfigs/*/url")
+                _xml_text(node)
+                for node in definition.findall(".//userRemoteConfigs/*/url")
             )
             if text
         ]
         branch_specs = [
             text
-            for text in (_xml_text(node) for node in definition.findall(".//branches/*/name"))
+            for text in (
+                _xml_text(node) for node in definition.findall(".//branches/*/name")
+            )
             if text
         ]
         result["repo_url"] = remote_urls[0] if remote_urls else None
@@ -399,8 +402,12 @@ class GetJobDefinitionTool(JenkinsOperationTool):
         scm_data = definition.get("scm") if isinstance(definition, dict) else None
         repo_url = _extract_repo_url(scm_data)
         branch_specs = _extract_branch_specs(scm_data)
-        script_path = definition.get("scriptPath") if isinstance(definition, dict) else None
-        inline_script = definition.get("script") if isinstance(definition, dict) else None
+        script_path = (
+            definition.get("scriptPath") if isinstance(definition, dict) else None
+        )
+        inline_script = (
+            definition.get("script") if isinstance(definition, dict) else None
+        )
 
         definition_type = "job_config_xml"
         if "CpsScmFlowDefinition" in definition_class:
@@ -426,10 +433,7 @@ class GetJobDefinitionTool(JenkinsOperationTool):
                 and not inline_script
                 and not script_path
             )
-            or (
-                definition_type == "scm_pipeline"
-                and (not repo_url or not script_path)
-            )
+            or (definition_type == "scm_pipeline" and (not repo_url or not script_path))
         )
         if needs_xml_fallback or xml_edit_enabled:
             try:
@@ -460,7 +464,9 @@ class GetJobDefinitionTool(JenkinsOperationTool):
 
         if xml_edit_enabled and xml_edit_supported:
             try:
-                xml_text = config_xml_text or jenkins_client.get_job_config_xml(job_name)
+                xml_text = config_xml_text or jenkins_client.get_job_config_xml(
+                    job_name
+                )
                 xml_path = _job_xml_path(
                     self.cache_manager,
                     self.multi_jenkins_manager,
@@ -477,7 +483,9 @@ class GetJobDefinitionTool(JenkinsOperationTool):
                     "to upload the edited config back to Jenkins."
                 )
             except Exception as e:
-                edit_instructions = f"XML editing is enabled, but XML download failed: {str(e)}"
+                edit_instructions = (
+                    f"XML editing is enabled, but XML download failed: {str(e)}"
+                )
         elif definition_type == "scm_pipeline":
             edit_instructions = (
                 "This job is SCM-backed. Modify the Jenkinsfile/script in source "

--- a/jenkins_mcp_enterprise/tools/jobs.py
+++ b/jenkins_mcp_enterprise/tools/jobs.py
@@ -1,0 +1,639 @@
+"""Job discovery and definition tools for Jenkins MCP."""
+
+import re
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from ..base import ParameterSpec
+from ..cache_manager import CacheManager
+from ..jenkins.jenkins_client import JenkinsClient
+from ..jenkins.job_name_utils import JobNameParser
+from .base_tools import JenkinsOperationTool
+from .common import CommonParameters
+
+DEFAULT_FIND_LIMIT = 25
+MAX_FIND_LIMIT = 200
+DEFAULT_INLINE_SCRIPT_CHARS = 20000
+
+
+def _sanitize_path_segment(value: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value.strip())
+    return cleaned or "unnamed"
+
+
+def _clamp_find_limit(value: int) -> int:
+    return max(1, min(value, MAX_FIND_LIMIT))
+
+
+def _xml_editing_enabled(multi_jenkins_manager) -> bool:
+    if not multi_jenkins_manager:
+        return False
+    return bool(multi_jenkins_manager.settings.get("enable_job_xml_editing", False))
+
+
+def _xml_workspace_root(cache_manager: CacheManager, multi_jenkins_manager) -> Path:
+    override = None
+    if multi_jenkins_manager:
+        override = multi_jenkins_manager.settings.get("job_xml_workspace_dir")
+    if override:
+        return Path(override).expanduser()
+    return cache_manager.config.base_dir / "job-definitions"
+
+
+def _job_xml_path(
+    cache_manager: CacheManager,
+    multi_jenkins_manager,
+    instance_id: Optional[str],
+    normalized_job_name: str,
+) -> Path:
+    workspace_root = _xml_workspace_root(cache_manager, multi_jenkins_manager)
+    instance_segment = _sanitize_path_segment(instance_id or "default")
+    job_parts = [
+        _sanitize_path_segment(part)
+        for part in normalized_job_name.split("/")
+        if part.strip()
+    ]
+    if not job_parts:
+        job_parts = ["unnamed-job"]
+    return workspace_root / instance_segment / Path(*job_parts) / "config.xml"
+
+
+def _extract_first_present(mapping: Dict[str, Any], *keys: str) -> Optional[Any]:
+    for key in keys:
+        value = mapping.get(key)
+        if value not in (None, "", [], {}):
+            return value
+    return None
+
+
+def _extract_repo_url(scm_data: Optional[Dict[str, Any]]) -> Optional[str]:
+    if not isinstance(scm_data, dict):
+        return None
+
+    user_remote_configs = scm_data.get("userRemoteConfigs") or []
+    for config in user_remote_configs:
+        if isinstance(config, dict):
+            url = _extract_first_present(config, "url", "remote")
+            if url:
+                return url
+
+    return _extract_first_present(scm_data, "url", "remote")
+
+
+def _extract_branch_specs(scm_data: Optional[Dict[str, Any]]) -> List[str]:
+    if not isinstance(scm_data, dict):
+        return []
+
+    branches = scm_data.get("branches") or []
+    branch_specs: List[str] = []
+    for branch in branches:
+        if isinstance(branch, dict):
+            name = branch.get("name")
+            if name:
+                branch_specs.append(name)
+        elif isinstance(branch, str) and branch:
+            branch_specs.append(branch)
+    return branch_specs
+
+
+def _extract_multibranch_source(
+    payload: Dict[str, Any],
+) -> tuple[Optional[str], List[str], Optional[str]]:
+    repo_url = None
+    branch_specs: List[str] = []
+    script_path = None
+
+    source_entries = payload.get("branchSources") or payload.get("sources") or []
+    for entry in source_entries:
+        if not isinstance(entry, dict):
+            continue
+        source = entry.get("source") or entry.get("scm") or entry
+        if isinstance(source, dict):
+            if repo_url is None:
+                repo_url = _extract_repo_url(source)
+            if not branch_specs:
+                branch_specs = _extract_branch_specs(source)
+
+    project_factory = payload.get("projectFactory") or payload.get("factory") or {}
+    if isinstance(project_factory, dict):
+        script_path = project_factory.get("scriptPath")
+
+    return repo_url, branch_specs, script_path
+
+
+def _xml_text(node: Optional[ET.Element]) -> Optional[str]:
+    if node is None or node.text is None:
+        return None
+    text = node.text.strip()
+    return text or None
+
+
+def _parse_job_definition_xml(xml_text: str) -> Dict[str, Any]:
+    """Extract pipeline definition details directly from Jenkins job XML."""
+    root = ET.fromstring(xml_text)
+    result: Dict[str, Any] = {"job_xml_root_tag": root.tag}
+
+    definition = root.find("definition")
+    if definition is None:
+        return result
+
+    definition_class = definition.get("class")
+    if definition_class:
+        result["definition_class"] = definition_class
+
+    if definition_class and "CpsScmFlowDefinition" in definition_class:
+        result["definition_type"] = "scm_pipeline"
+        result["script_path"] = _xml_text(definition.find("scriptPath"))
+        remote_urls = [
+            text
+            for text in (
+                _xml_text(node) for node in definition.findall(".//userRemoteConfigs/*/url")
+            )
+            if text
+        ]
+        branch_specs = [
+            text
+            for text in (_xml_text(node) for node in definition.findall(".//branches/*/name"))
+            if text
+        ]
+        result["repo_url"] = remote_urls[0] if remote_urls else None
+        result["branch_specs"] = branch_specs
+    elif definition_class and "CpsFlowDefinition" in definition_class:
+        result["definition_type"] = "inline_pipeline"
+        result["inline_script"] = _xml_text(definition.find("script"))
+    elif root.tag.endswith("WorkflowMultiBranchProject"):
+        result["definition_type"] = "multibranch_pipeline"
+
+    return result
+
+
+class FindJobsTool(JenkinsOperationTool):
+    """Find Jenkins jobs by name/path substring."""
+
+    def __init__(
+        self,
+        jenkins_client: JenkinsClient,
+        multi_jenkins_manager=None,
+    ):
+        super().__init__(
+            jenkins_client=jenkins_client,
+            multi_jenkins_manager=multi_jenkins_manager,
+        )
+
+    @property
+    def name(self) -> str:
+        return "find_jobs"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Searches Jenkins jobs by name, full path, or URL so callers can find "
+            "the exact pipeline/job identifier before triggering or inspecting it. "
+            "Queries a single Jenkins instance per call (resolved from "
+            "`jenkins_url`)."
+        )
+
+    @property
+    def parameters(self) -> List[ParameterSpec]:
+        return [
+            CommonParameters.jenkins_url_param(),
+            ParameterSpec(
+                "query",
+                str,
+                "Case-insensitive substring to match against job name, full path, or URL.",
+                required=True,
+            ),
+            ParameterSpec(
+                "limit",
+                int,
+                f"Maximum number of matching jobs to return (default {DEFAULT_FIND_LIMIT}, max {MAX_FIND_LIMIT}).",
+                required=False,
+                default=DEFAULT_FIND_LIMIT,
+            ),
+            ParameterSpec(
+                "folder",
+                str,
+                "Optional folder/job path prefix to constrain the search (for example 'team-a/services').",
+                required=False,
+                default="",
+            ),
+        ]
+
+    def _execute_impl(self, **kwargs) -> Dict[str, Any]:
+        jenkins_url = kwargs["jenkins_url"]
+        query = (kwargs["query"] or "").strip().lower()
+        limit = _clamp_find_limit(kwargs.get("limit"))
+        folder = JobNameParser.normalize_job_name(kwargs.get("folder") or "")
+
+        try:
+            instance_id = self.resolve_jenkins_instance(jenkins_url)
+            jenkins_client = self.get_jenkins_client(instance_id)
+        except Exception as e:
+            return {
+                "jenkins_url": jenkins_url,
+                "query": kwargs["query"],
+                "error": f"Jenkins instance resolution failed: {str(e)}",
+                "instructions": self.get_instance_instructions(),
+            }
+
+        try:
+            jobs = jenkins_client.list_jobs()
+        except Exception as e:
+            return {
+                "jenkins_url": jenkins_url,
+                "query": kwargs["query"],
+                "error": f"Failed to list Jenkins jobs: {str(e)}",
+            }
+
+        matches: List[Dict[str, Any]] = []
+        folder_prefix = f"{folder}/" if folder else ""
+        for job in jobs:
+            raw_name = (
+                job.get("fullname")
+                or job.get("fullName")
+                or job.get("name")
+                or job.get("displayName")
+                or ""
+            )
+            normalized_name = JobNameParser.normalize_job_name(raw_name)
+            if folder and not (
+                normalized_name == folder or normalized_name.startswith(folder_prefix)
+            ):
+                continue
+
+            haystacks = [
+                normalized_name.lower(),
+                str(job.get("name") or "").lower(),
+                str(job.get("displayName") or "").lower(),
+                str(job.get("url") or "").lower(),
+            ]
+            if query not in " ".join(haystacks):
+                continue
+
+            matches.append(
+                {
+                    "job_name": normalized_name,
+                    "display_name": job.get("name") or normalized_name.split("/")[-1],
+                    "url": job.get("url"),
+                    "job_type": job.get("_class") or job.get("type"),
+                    "color": job.get("color"),
+                }
+            )
+
+            if len(matches) >= limit:
+                break
+
+        return {
+            "jenkins_url": jenkins_url,
+            "query": kwargs["query"],
+            "folder": folder or None,
+            "limit": limit,
+            "returned_count": len(matches),
+            "jobs": matches,
+        }
+
+
+class GetJobDefinitionTool(JenkinsOperationTool):
+    """Inspect a Jenkins job definition and optionally stage config XML for editing."""
+
+    def __init__(
+        self,
+        jenkins_client: JenkinsClient,
+        cache_manager: CacheManager,
+        multi_jenkins_manager=None,
+    ):
+        self.cache_manager = cache_manager
+        super().__init__(
+            jenkins_client=jenkins_client,
+            multi_jenkins_manager=multi_jenkins_manager,
+        )
+
+    @property
+    def name(self) -> str:
+        return "get_job_definition"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Inspects how a Jenkins job is defined. For SCM-backed pipelines, it "
+            "returns source-control location details such as repository URL, branch "
+            "spec, and Jenkinsfile/script path. For inline or XML-backed jobs, it "
+            "returns the inline script when present and, if server-side XML editing "
+            "is enabled, downloads the job config XML to a local workspace path and "
+            "returns instructions for patching and re-uploading it."
+        )
+
+    @property
+    def parameters(self) -> List[ParameterSpec]:
+        return [
+            CommonParameters.job_name_param(),
+            CommonParameters.jenkins_url_param(),
+            ParameterSpec(
+                "max_inline_script_chars",
+                int,
+                (
+                    "Maximum number of inline pipeline script characters to return "
+                    f"(default {DEFAULT_INLINE_SCRIPT_CHARS}). Use 0 to omit the "
+                    "inline script body."
+                ),
+                required=False,
+                default=DEFAULT_INLINE_SCRIPT_CHARS,
+            ),
+        ]
+
+    def _execute_impl(self, **kwargs) -> Dict[str, Any]:
+        job_name = kwargs["job_name"]
+        jenkins_url = kwargs["jenkins_url"]
+        max_inline_script_chars = max(0, kwargs.get("max_inline_script_chars") or 0)
+        normalized_job = JobNameParser.normalize_job_name(job_name)
+
+        try:
+            instance_id = self.resolve_jenkins_instance(jenkins_url)
+            jenkins_client = self.get_jenkins_client(instance_id)
+        except Exception as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "error": f"Jenkins instance resolution failed: {str(e)}",
+                "instructions": self.get_instance_instructions(),
+            }
+
+        api_job_path = JobNameParser.to_jenkins_api_path(job_name)
+        api_url = f"{jenkins_client.config.url.rstrip('/')}/{api_job_path}/api/json"
+
+        try:
+            response = jenkins_client.connection.session.get(
+                api_url,
+                params={"depth": 2},
+                timeout=jenkins_client.config.timeout,
+            )
+            if response.status_code == 404:
+                return {
+                    "job_name": normalized_job,
+                    "jenkins_url": jenkins_url,
+                    "api_url": api_url,
+                    "error": "Job not found (HTTP 404).",
+                }
+            response.raise_for_status()
+            payload = response.json()
+        except requests.RequestException as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "api_url": api_url,
+                "error": f"Jenkins API request failed: {str(e)}",
+            }
+        except ValueError as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "api_url": api_url,
+                "error": f"Invalid JSON response from Jenkins: {str(e)}",
+            }
+
+        definition = payload.get("definition") or {}
+        definition_class = str(definition.get("class") or "")
+        scm_data = definition.get("scm") if isinstance(definition, dict) else None
+        repo_url = _extract_repo_url(scm_data)
+        branch_specs = _extract_branch_specs(scm_data)
+        script_path = definition.get("scriptPath") if isinstance(definition, dict) else None
+        inline_script = definition.get("script") if isinstance(definition, dict) else None
+
+        definition_type = "job_config_xml"
+        if "CpsScmFlowDefinition" in definition_class:
+            definition_type = "scm_pipeline"
+        elif "CpsFlowDefinition" in definition_class:
+            definition_type = "inline_pipeline"
+        elif "WorkflowMultiBranchProject" in str(payload.get("_class") or ""):
+            definition_type = "multibranch_pipeline"
+            mb_repo_url, mb_branch_specs, mb_script_path = _extract_multibranch_source(
+                payload
+            )
+            repo_url = repo_url or mb_repo_url
+            branch_specs = branch_specs or mb_branch_specs
+            script_path = script_path or mb_script_path
+
+        config_xml_text = None
+        xml_edit_enabled = _xml_editing_enabled(self.multi_jenkins_manager)
+        needs_xml_fallback = (
+            not definition_class
+            or (
+                definition_type in {"job_config_xml", "multibranch_pipeline"}
+                and not repo_url
+                and not inline_script
+                and not script_path
+            )
+            or (
+                definition_type == "scm_pipeline"
+                and (not repo_url or not script_path)
+            )
+        )
+        if needs_xml_fallback or xml_edit_enabled:
+            try:
+                config_xml_text = jenkins_client.get_job_config_xml(job_name)
+            except Exception:
+                config_xml_text = None
+
+        if config_xml_text:
+            parsed_xml = _parse_job_definition_xml(config_xml_text)
+            definition_class = definition_class or parsed_xml.get("definition_class")
+            definition_type = parsed_xml.get("definition_type") or definition_type
+            repo_url = repo_url or parsed_xml.get("repo_url")
+            branch_specs = branch_specs or parsed_xml.get("branch_specs") or []
+            script_path = script_path or parsed_xml.get("script_path")
+            inline_script = inline_script or parsed_xml.get("inline_script")
+
+        inline_script_truncated = False
+        if inline_script and max_inline_script_chars:
+            if len(inline_script) > max_inline_script_chars:
+                inline_script = inline_script[:max_inline_script_chars]
+                inline_script_truncated = True
+        elif max_inline_script_chars == 0:
+            inline_script = None
+
+        xml_edit_supported = definition_type != "scm_pipeline"
+        local_xml_path = None
+        edit_instructions = None
+
+        if xml_edit_enabled and xml_edit_supported:
+            try:
+                xml_text = config_xml_text or jenkins_client.get_job_config_xml(job_name)
+                xml_path = _job_xml_path(
+                    self.cache_manager,
+                    self.multi_jenkins_manager,
+                    instance_id,
+                    normalized_job,
+                )
+                xml_path.parent.mkdir(parents=True, exist_ok=True)
+                xml_path.write_text(xml_text, encoding="utf-8")
+                local_xml_path = str(xml_path)
+                edit_instructions = (
+                    "Jenkins job XML was downloaded locally. Modify that file with "
+                    "local patch/edit tools, then call `apply_job_xml_edit` with "
+                    "the same `job_name`, `jenkins_url`, and this `local_xml_path` "
+                    "to upload the edited config back to Jenkins."
+                )
+            except Exception as e:
+                edit_instructions = f"XML editing is enabled, but XML download failed: {str(e)}"
+        elif definition_type == "scm_pipeline":
+            edit_instructions = (
+                "This job is SCM-backed. Modify the Jenkinsfile/script in source "
+                "control at the returned repository/path instead of editing Jenkins "
+                "job XML."
+            )
+        else:
+            edit_instructions = (
+                "Server-side XML editing is disabled. To enable it, set "
+                "`settings.enable_job_xml_editing: true` in the MCP config."
+            )
+
+        return {
+            "job_name": normalized_job,
+            "jenkins_url": jenkins_url,
+            "display_name": payload.get("displayName") or payload.get("name"),
+            "job_type": payload.get("_class"),
+            "definition_type": definition_type,
+            "definition_class": definition_class or None,
+            "description": payload.get("description"),
+            "url": payload.get("url"),
+            "disabled": payload.get("disabled"),
+            "source_location": {
+                "repo_url": repo_url,
+                "branch_specs": branch_specs,
+                "script_path": script_path,
+            },
+            "inline_script": inline_script,
+            "inline_script_truncated": inline_script_truncated,
+            "xml_editing_enabled": xml_edit_enabled,
+            "xml_editing_supported": xml_edit_supported,
+            "local_xml_path": local_xml_path,
+            "edit_upload_tool": (
+                "apply_job_xml_edit" if xml_edit_enabled and local_xml_path else None
+            ),
+            "edit_instructions": edit_instructions,
+        }
+
+
+class ApplyJobXmlEditTool(JenkinsOperationTool):
+    """Upload a locally edited Jenkins job config XML back to Jenkins."""
+
+    def __init__(
+        self,
+        jenkins_client: JenkinsClient,
+        cache_manager: CacheManager,
+        multi_jenkins_manager=None,
+    ):
+        self.cache_manager = cache_manager
+        super().__init__(
+            jenkins_client=jenkins_client,
+            multi_jenkins_manager=multi_jenkins_manager,
+        )
+
+    @property
+    def name(self) -> str:
+        return "apply_job_xml_edit"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Uploads a locally edited Jenkins job config XML back to Jenkins. This "
+            "tool is intended for XML files previously downloaded by "
+            "`get_job_definition` when server-side XML editing is enabled."
+        )
+
+    @property
+    def parameters(self) -> List[ParameterSpec]:
+        return [
+            CommonParameters.job_name_param(),
+            CommonParameters.jenkins_url_param(),
+            ParameterSpec(
+                "local_xml_path",
+                str,
+                "Absolute path to the locally edited Jenkins config XML file downloaded by get_job_definition.",
+                required=True,
+            ),
+        ]
+
+    def _execute_impl(self, **kwargs) -> Dict[str, Any]:
+        job_name = kwargs["job_name"]
+        jenkins_url = kwargs["jenkins_url"]
+        local_xml_path = kwargs["local_xml_path"]
+        normalized_job = JobNameParser.normalize_job_name(job_name)
+
+        if not _xml_editing_enabled(self.multi_jenkins_manager):
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_xml_path": local_xml_path,
+                "error": (
+                    "Server-side XML editing is disabled. Enable "
+                    "`settings.enable_job_xml_editing: true` to use this tool."
+                ),
+            }
+
+        try:
+            instance_id = self.resolve_jenkins_instance(jenkins_url)
+            jenkins_client = self.get_jenkins_client(instance_id)
+        except Exception as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_xml_path": local_xml_path,
+                "error": f"Jenkins instance resolution failed: {str(e)}",
+                "instructions": self.get_instance_instructions(),
+            }
+
+        workspace_root = _xml_workspace_root(
+            self.cache_manager, self.multi_jenkins_manager
+        ).resolve()
+        candidate_path = Path(local_xml_path).expanduser().resolve()
+        try:
+            candidate_path.relative_to(workspace_root)
+        except ValueError:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_xml_path": local_xml_path,
+                "error": (
+                    "local_xml_path must be inside the configured Jenkins XML "
+                    "workspace directory returned by get_job_definition."
+                ),
+            }
+
+        if not candidate_path.exists():
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_xml_path": local_xml_path,
+                "error": "local_xml_path does not exist.",
+            }
+
+        if candidate_path.suffix.lower() != ".xml":
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_xml_path": local_xml_path,
+                "error": "local_xml_path must point to an XML file.",
+            }
+
+        try:
+            xml_text = candidate_path.read_text(encoding="utf-8")
+            jenkins_client.reconfig_job_xml(job_name, xml_text)
+        except Exception as e:
+            return {
+                "job_name": normalized_job,
+                "jenkins_url": jenkins_url,
+                "local_xml_path": local_xml_path,
+                "error": f"Failed to upload edited Jenkins job XML: {str(e)}",
+            }
+
+        return {
+            "job_name": normalized_job,
+            "jenkins_url": jenkins_url,
+            "local_xml_path": str(candidate_path),
+            "updated": True,
+            "message": "Uploaded edited Jenkins job XML back to Jenkins.",
+        }

--- a/jenkins_mcp_enterprise/vector_manager.py
+++ b/jenkins_mcp_enterprise/vector_manager.py
@@ -76,6 +76,7 @@ class QdrantVectorManager:
                 host=self._extract_host(config.host),
                 port=self._extract_port(config.host),
                 timeout=30,
+                check_compatibility=False,
             )
             logger.info(f"Connected to Qdrant at {config.host}")
         except Exception as e:
@@ -85,7 +86,10 @@ class QdrantVectorManager:
         # Load embedding model
         try:
             self.model = SentenceTransformer(config.embedding_model)
-            self.embedding_dim = self.model.get_sentence_embedding_dimension()
+            if hasattr(self.model, "get_embedding_dimension"):
+                self.embedding_dim = self.model.get_embedding_dimension()
+            else:
+                self.embedding_dim = self.model.get_sentence_embedding_dimension()
             logger.info(
                 f"Loaded embedding model {config.embedding_model} with dimension {self.embedding_dim}"
             )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
@@ -7,11 +7,13 @@ markers =
     performance: marks tests as performance tests
     slow: marks tests as slow running
     real_jenkins: marks tests that require real Jenkins instance
+
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
     ignore::pytest.PytestUnraisableExceptionWarning
     ignore::pytest_asyncio.plugin.PytestDeprecationWarning
+
 addopts =
     --tb=short
     -v

--- a/tests/mcp_integration/test_error_scenarios.py
+++ b/tests/mcp_integration/test_error_scenarios.py
@@ -17,18 +17,27 @@ class TestErrorScenarios:
 
     @pytest.mark.asyncio
     async def test_jenkins_connection_failure(self, seeded_jenkins_test_env):
-        """Test behavior when Jenkins is unreachable"""
+        """Server should still start, and tool calls should fail cleanly when Jenkins is unreachable."""
         config = seeded_jenkins_test_env.config
         jenkins = seeded_jenkins_test_env.jenkins_double
 
         # Stop the Jenkins double to simulate connection failure
         jenkins.stop()
 
-        with pytest.raises(TimeoutError) as excinfo:
-            async with MCPTestClient("jenkins_mcp_enterprise.server", config) as client:
-                pass
+        async with MCPTestClient("jenkins_mcp_enterprise.server", config) as client:
+            result = await client.call_tool(
+                "get_jenkins_job_parameters",
+                {"job_name": "sample-job", "jenkins_url": config["jenkins"]["url"]},
+            )
 
-        assert "server failed to initialize" in str(excinfo.value).lower()
+            assert result.get("isError") is True
+            assert "content" in result
+            error_msg = result["content"][0]["text"].lower()
+            assert (
+                "failed to get job parameters" in error_msg
+                or "connection" in error_msg
+                or "refused" in error_msg
+            )
 
     @pytest.mark.asyncio
     async def test_invalid_build_number(self, seeded_jenkins_test_env):
@@ -117,7 +126,7 @@ class TestErrorScenarios:
             if result.get("isError"):
                 assert "content" in result
                 error_msg = result["content"][0]["text"].lower()
-                assert "failed to fetch" in error_msg
+                assert "failed to fetch" in error_msg or "build not found" in error_msg
 
     @pytest.mark.asyncio
     async def test_large_parameter_values(self, seeded_jenkins_test_env):

--- a/tests/mcp_integration/test_resources.py
+++ b/tests/mcp_integration/test_resources.py
@@ -46,11 +46,7 @@ def _extract_json_from_contents(contents: list) -> dict | None:
             return item["json"]
 
     for item in contents:
-        if (
-            isinstance(item, dict)
-            and item.get("mimeType") == "application/json"
-            and isinstance(item.get("text"), str)
-        ):
+        if isinstance(item, dict) and isinstance(item.get("text"), str):
             try:
                 parsed = json.loads(item["text"])
                 if isinstance(parsed, dict):

--- a/tests/mcp_integration/test_simple_validation.py
+++ b/tests/mcp_integration/test_simple_validation.py
@@ -1,6 +1,7 @@
 """Simple validation tests for MCP integration framework"""
 
 import asyncio
+import os
 import shutil
 import subprocess
 import sys
@@ -20,9 +21,10 @@ class TestSimpleValidation:
     @pytest_asyncio.fixture
     async def simple_jenkins(self):
         """Simple Jenkins test double"""
-        jenkins = JenkinsTestDouble(port=18083)
+        jenkins = JenkinsTestDouble(port=0)
         jenkins.add_job("sample-job", {"name": "sample-job", "nextBuildNumber": 42})
         jenkins.start()
+        jenkins.port = jenkins.server.server_port
 
         yield jenkins
 
@@ -33,7 +35,7 @@ class TestSimpleValidation:
         """Test that Jenkins test double works correctly"""
         # Simple test that the test double is running
         assert simple_jenkins is not None
-        assert simple_jenkins.port == 18083
+        assert simple_jenkins.port > 0
         import requests
 
         # Test whoami endpoint
@@ -58,6 +60,9 @@ class TestSimpleValidation:
     async def test_tool_validator_with_real_jenkins(self):
         """Test tool validator with real Jenkins credentials"""
         from jenkins_mcp_enterprise.tool_validator import validate_all_tools
+
+        if not os.getenv("JENKINS_URL") or not os.getenv("JENKINS_TOKEN"):
+            pytest.skip("Real Jenkins validation requires JENKINS_URL and JENKINS_TOKEN")
 
         # Run with real Jenkins
         success = validate_all_tools(use_real_jenkins=True)
@@ -151,8 +156,8 @@ class TestSimpleValidation:
         from .test_doubles import JenkinsTestDouble, QdrantTestDouble
 
         # Test that test doubles can be instantiated
-        jenkins = JenkinsTestDouble(port=18084)
-        qdrant = QdrantTestDouble(port=16336)
+        jenkins = JenkinsTestDouble(port=0)
+        qdrant = QdrantTestDouble(port=0)
 
         # Test that MCP test client can be instantiated
         client = MCPTestClient("dummy_server.py", {"test": "config"})
@@ -164,6 +169,8 @@ class TestSimpleValidation:
         # Test that test doubles can start and stop
         jenkins.start()
         qdrant.start()
+        jenkins.port = jenkins.server.server_port
+        qdrant.port = qdrant.server.server_port
 
         # Basic connectivity test
         import requests

--- a/tests/mcp_integration/test_simple_validation.py
+++ b/tests/mcp_integration/test_simple_validation.py
@@ -62,7 +62,9 @@ class TestSimpleValidation:
         from jenkins_mcp_enterprise.tool_validator import validate_all_tools
 
         if not os.getenv("JENKINS_URL") or not os.getenv("JENKINS_TOKEN"):
-            pytest.skip("Real Jenkins validation requires JENKINS_URL and JENKINS_TOKEN")
+            pytest.skip(
+                "Real Jenkins validation requires JENKINS_URL and JENKINS_TOKEN"
+            )
 
         # Run with real Jenkins
         success = validate_all_tools(use_real_jenkins=True)

--- a/tests/mcp_integration/test_tool_scenarios.py
+++ b/tests/mcp_integration/test_tool_scenarios.py
@@ -46,11 +46,13 @@ class TestToolScenarios:
             expected_tools = [
                 "trigger_build",
                 "trigger_build_async",
+                "find_jobs",
                 "get_log_context",
                 "filter_errors_grep",
                 "trigger_build_with_subs",
                 "diagnose_build_failure",
                 "get_jenkins_job_parameters",
+                "get_job_definition",
             ]
 
             for expected in expected_tools:

--- a/tests/test_build_manager.py
+++ b/tests/test_build_manager.py
@@ -40,3 +40,42 @@ def test_trigger_build_passes_explicit_job_trigger_token():
     )
     assert build.build_number == 8
     assert build.url == "http://jenkins.example/job/deep-01/8/"
+
+
+def test_trigger_build_retries_after_stale_crumb_error():
+    client = Mock()
+    client.build_job.side_effect = [
+        Exception("403 Forbidden: No valid crumb was included in the request"),
+        44,
+    ]
+    client.get_queue_item.return_value = {"executable": {"number": 9}}
+    connection = SimpleNamespace(
+        client=client,
+        config=SimpleNamespace(url="http://jenkins.example", token="admin123"),
+        should_refresh_on_error=lambda error: "crumb" in str(error).lower(),
+        refresh_connection=Mock(),
+    )
+
+    manager = BuildManager(connection)
+    build = manager.trigger_build("deep-01")
+
+    assert client.build_job.call_count == 2
+    connection.refresh_connection.assert_called_once_with()
+    assert build.build_number == 9
+
+
+def test_trigger_build_falls_back_when_queue_item_disappears():
+    client = Mock()
+    client.build_job.return_value = 45
+    client.get_queue_item.side_effect = Exception("queue number[45] does not exist")
+    client.get_job_info.return_value = {"lastBuild": {"number": 10}}
+    connection = SimpleNamespace(
+        client=client,
+        config=SimpleNamespace(url="http://jenkins.example", token="admin123"),
+    )
+
+    manager = BuildManager(connection)
+    build = manager.trigger_build("deep-01")
+
+    client.get_job_info.assert_called_once_with("deep-01")
+    assert build.build_number == 10

--- a/tests/test_tool_factory.py
+++ b/tests/test_tool_factory.py
@@ -5,12 +5,12 @@ from jenkins_mcp_enterprise.tool_factory import ToolFactory
 
 
 class FakeContainer(DIContainer):
-    def __init__(self, vector_search_disabled, xml_editing_enabled=False):
+    def __init__(self, vector_search_disabled, job_editing_enabled=False):
         self._jenkins_client = Mock()
         self._cache_manager = Mock()
         self._multi_jenkins_manager = Mock()
         self._multi_jenkins_manager.settings = {
-            "enable_job_xml_editing": xml_editing_enabled
+            "enable_job_editing": job_editing_enabled
         }
         self._vector_manager = Mock()
         self._vector_manager.vector_search_disabled = vector_search_disabled
@@ -34,7 +34,7 @@ def test_tool_factory_omits_semantic_search_when_vector_search_disabled():
     tools = factory.create_tools()
 
     assert "semantic_search" not in tools
-    assert "apply_job_xml_edit" not in tools
+    assert "apply_job_edit" not in tools
     assert factory.get_tool_count() == 13
 
 
@@ -49,10 +49,10 @@ def test_tool_factory_includes_semantic_search_when_vector_search_enabled():
 
 def test_tool_factory_registers_xml_edit_tool_only_when_enabled():
     factory = ToolFactory(
-        FakeContainer(vector_search_disabled=True, xml_editing_enabled=True)
+        FakeContainer(vector_search_disabled=True, job_editing_enabled=True)
     )
 
     tools = factory.create_tools()
 
-    assert "apply_job_xml_edit" in tools
+    assert "apply_job_edit" in tools
     assert factory.get_tool_count() == 14

--- a/tests/test_tool_factory.py
+++ b/tests/test_tool_factory.py
@@ -5,10 +5,13 @@ from jenkins_mcp_enterprise.tool_factory import ToolFactory
 
 
 class FakeContainer(DIContainer):
-    def __init__(self, vector_search_disabled):
+    def __init__(self, vector_search_disabled, xml_editing_enabled=False):
         self._jenkins_client = Mock()
         self._cache_manager = Mock()
         self._multi_jenkins_manager = Mock()
+        self._multi_jenkins_manager.settings = {
+            "enable_job_xml_editing": xml_editing_enabled
+        }
         self._vector_manager = Mock()
         self._vector_manager.vector_search_disabled = vector_search_disabled
 
@@ -31,7 +34,8 @@ def test_tool_factory_omits_semantic_search_when_vector_search_disabled():
     tools = factory.create_tools()
 
     assert "semantic_search" not in tools
-    assert factory.get_tool_count() == 9
+    assert "apply_job_xml_edit" not in tools
+    assert factory.get_tool_count() == 13
 
 
 def test_tool_factory_includes_semantic_search_when_vector_search_enabled():
@@ -40,4 +44,15 @@ def test_tool_factory_includes_semantic_search_when_vector_search_enabled():
     tools = factory.create_tools()
 
     assert "semantic_search" in tools
-    assert factory.get_tool_count() == 10
+    assert factory.get_tool_count() == 14
+
+
+def test_tool_factory_registers_xml_edit_tool_only_when_enabled():
+    factory = ToolFactory(
+        FakeContainer(vector_search_disabled=True, xml_editing_enabled=True)
+    )
+
+    tools = factory.create_tools()
+
+    assert "apply_job_xml_edit" in tools
+    assert factory.get_tool_count() == 14

--- a/tests/tools/test_builds.py
+++ b/tests/tools/test_builds.py
@@ -213,6 +213,46 @@ class TestListJobBuildsToolExecution:
         tree_arg = client.connection.session.get.call_args.kwargs["params"]["tree"]
         assert tree_arg == f"{custom_tree}{{0,5}}"
 
+    def test_around_build_number_returns_neighbor_window(self):
+        response = _make_response(
+            json_payload={
+                "builds": [
+                    {"number": 12, "result": "SUCCESS"},
+                    {"number": 11, "result": "FAILURE"},
+                    {"number": 10, "result": "SUCCESS"},
+                    {"number": 9, "result": "SUCCESS"},
+                ]
+            }
+        )
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            around_build_number=10,
+            before=1,
+            after=1,
+        )
+
+        assert result.success is True
+        assert [build["number"] for build in result.data["builds"]] == [11, 10, 9]
+
+    def test_around_build_number_requires_number_in_tree(self):
+        response = _make_response(json_payload={"builds": []})
+        client = _make_jenkins_client(get_response=response)
+        tool = ListJobBuildsTool(jenkins_client=client)
+
+        result = tool.execute(
+            job_name="my-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            around_build_number=10,
+            tree="builds[result,description]",
+        )
+
+        assert result.success is True
+        assert "requires build numbers" in result.data["error"]
+
     def test_empty_tree_override_falls_back_to_default(self):
         response = _make_response(json_payload={"builds": []})
         client = _make_jenkins_client(get_response=response)
@@ -575,4 +615,4 @@ def test_tools_are_registered_by_tool_factory():
 
     assert "list_job_builds" in tools
     assert "get_build_info" in tools
-    assert factory.get_tool_count() == 11
+    assert factory.get_tool_count() == 13

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -1,0 +1,240 @@
+"""Unit tests for ``tools.jobs`` (find_jobs, get_job_definition, apply_job_xml_edit)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import requests
+
+from jenkins_mcp_enterprise.tools.jobs import (
+    ApplyJobXmlEditTool,
+    FindJobsTool,
+    GetJobDefinitionTool,
+)
+
+
+def _make_response(*, status_code: int = 200, json_payload=None) -> MagicMock:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.json.return_value = json_payload if json_payload is not None else {}
+
+    def _raise_for_status():
+        if status_code >= 400:
+            err = requests.HTTPError(f"HTTP {status_code}")
+            err.response = response
+            raise err
+
+    response.raise_for_status.side_effect = _raise_for_status
+    return response
+
+
+def _make_jenkins_client(
+    *,
+    base_url: str = "https://jenkins.example.com",
+    timeout: int = 30,
+    job_list=None,
+    job_xml: str = "<xml />",
+    api_response: MagicMock = None,
+) -> MagicMock:
+    session = MagicMock()
+    session.get.return_value = api_response if api_response is not None else _make_response()
+
+    client = MagicMock()
+    client.config = SimpleNamespace(url=base_url, timeout=timeout)
+    client.connection = SimpleNamespace(session=session)
+    client.list_jobs.return_value = job_list if job_list is not None else []
+    client.get_job_config_xml.return_value = job_xml
+    client.reconfig_job_xml.return_value = True
+    return client
+
+
+def _make_manager(
+    xml_editing_enabled: bool = False, client: MagicMock = None
+) -> MagicMock:
+    manager = MagicMock()
+    manager.settings = {"enable_job_xml_editing": xml_editing_enabled}
+    manager.get_usage_instructions.return_value = "configure instances"
+    manager.resolve_jenkins_url.return_value = "prod"
+    manager.get_jenkins_client.return_value = client
+    return manager
+
+
+def _make_cache_manager(tmp_path: Path) -> MagicMock:
+    cache_manager = MagicMock()
+    cache_manager.config = SimpleNamespace(base_dir=tmp_path)
+    return cache_manager
+
+
+class TestFindJobsTool:
+    def test_finds_matching_jobs(self):
+        jobs = [
+            {
+                "fullname": "team-a/service-a",
+                "name": "service-a",
+                "url": "https://jenkins.example.com/job/team-a/job/service-a/",
+                "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+                "color": "blue",
+            },
+            {
+                "fullname": "team-b/other-job",
+                "name": "other-job",
+                "url": "https://jenkins.example.com/job/team-b/job/other-job/",
+                "_class": "hudson.model.FreeStyleProject",
+                "color": "disabled",
+            },
+        ]
+        client = _make_jenkins_client(job_list=jobs)
+        tool = FindJobsTool(jenkins_client=client)
+
+        result = tool.execute(
+            jenkins_url="https://jenkins.example.com",
+            query="service",
+            limit=10,
+        )
+
+        assert result.success is True
+        assert result.data["returned_count"] == 1
+        assert result.data["jobs"][0]["job_name"] == "team-a/service-a"
+
+
+class TestGetJobDefinitionTool:
+    def test_returns_scm_location_for_scm_pipeline(self, tmp_path):
+        response = _make_response(
+            json_payload={
+                "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+                "displayName": "service-a",
+                "url": "https://jenkins.example.com/job/service-a/",
+            }
+        )
+        client = _make_jenkins_client(api_response=response)
+        client.get_job_config_xml.return_value = """
+<flow-definition plugin=\"workflow-job@1.0\">
+  <definition class=\"org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition\" plugin=\"workflow-cps@1.0\">
+    <scm class=\"hudson.plugins.git.GitSCM\" plugin=\"git@1.0\">
+      <userRemoteConfigs>
+        <hudson.plugins.git.UserRemoteConfig>
+          <url>git@github.com:example/service-a.git</url>
+        </hudson.plugins.git.UserRemoteConfig>
+      </userRemoteConfigs>
+      <branches>
+        <hudson.plugins.git.BranchSpec>
+          <name>*/main</name>
+        </hudson.plugins.git.BranchSpec>
+      </branches>
+    </scm>
+    <scriptPath>ci/Jenkinsfile</scriptPath>
+  </definition>
+</flow-definition>
+""".strip()
+        tool = GetJobDefinitionTool(
+            jenkins_client=client,
+            cache_manager=_make_cache_manager(tmp_path),
+        )
+
+        result = tool.execute(
+            job_name="service-a",
+            jenkins_url="https://jenkins.example.com",
+        )
+
+        assert result.success is True
+        data = result.data
+        assert data["definition_type"] == "scm_pipeline"
+        assert data["source_location"]["repo_url"] == "git@github.com:example/service-a.git"
+        assert data["source_location"]["script_path"] == "ci/Jenkinsfile"
+        assert data["local_xml_path"] is None
+        assert "source control" in data["edit_instructions"]
+
+    def test_downloads_xml_for_inline_pipeline_when_editing_enabled(self, tmp_path):
+        response = _make_response(
+            json_payload={
+                "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
+                "displayName": "inline-pipeline",
+            }
+        )
+        client = _make_jenkins_client(
+            api_response=response,
+            job_xml=(
+                "<flow-definition>"
+                "<definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\">"
+                "<script>pipeline { agent any; stages { stage('x') { steps { echo 'hello' } } } }</script>"
+                "</definition>"
+                "</flow-definition>"
+            ),
+        )
+        manager = _make_manager(xml_editing_enabled=True, client=client)
+        tool = GetJobDefinitionTool(
+            jenkins_client=client,
+            cache_manager=_make_cache_manager(tmp_path),
+            multi_jenkins_manager=manager,
+        )
+
+        result = tool.execute(
+            job_name="team-a/inline-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            max_inline_script_chars=20,
+        )
+
+        assert result.success is True
+        data = result.data
+        assert data["definition_type"] == "inline_pipeline"
+        assert data["inline_script_truncated"] is True
+        assert data["local_xml_path"] is not None
+        xml_path = Path(data["local_xml_path"])
+        assert xml_path.exists()
+        assert (
+            xml_path.read_text(encoding="utf-8")
+            == "<flow-definition><definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\"><script>pipeline { agent any; stages { stage('x') { steps { echo 'hello' } } } }</script></definition></flow-definition>"
+        )
+        assert "apply_job_xml_edit" == data["edit_upload_tool"]
+        assert "downloaded locally" in data["edit_instructions"]
+
+
+class TestApplyJobXmlEditTool:
+    def test_uploads_local_xml_back_to_jenkins(self, tmp_path):
+        workspace_root = tmp_path / "job-definitions"
+        xml_path = workspace_root / "prod" / "team-a" / "inline-pipeline" / "config.xml"
+        xml_path.parent.mkdir(parents=True, exist_ok=True)
+        xml_path.write_text("<flow-definition updated='true' />", encoding="utf-8")
+
+        client = _make_jenkins_client()
+        manager = _make_manager(xml_editing_enabled=True, client=client)
+        manager.settings["job_xml_workspace_dir"] = str(workspace_root)
+        tool = ApplyJobXmlEditTool(
+            jenkins_client=client,
+            cache_manager=_make_cache_manager(tmp_path),
+            multi_jenkins_manager=manager,
+        )
+
+        result = tool.execute(
+            job_name="team-a/inline-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            local_xml_path=str(xml_path),
+        )
+
+        assert result.success is True
+        assert result.data["updated"] is True
+        client.reconfig_job_xml.assert_called_once_with(
+            "team-a/inline-pipeline", "<flow-definition updated='true' />"
+        )
+
+    def test_rejects_xml_path_outside_workspace(self, tmp_path):
+        xml_path = tmp_path / "outside.xml"
+        xml_path.write_text("<flow-definition />", encoding="utf-8")
+
+        client = _make_jenkins_client()
+        manager = _make_manager(xml_editing_enabled=True, client=client)
+        manager.settings["job_xml_workspace_dir"] = str(tmp_path / "job-definitions")
+        tool = ApplyJobXmlEditTool(
+            jenkins_client=client,
+            cache_manager=_make_cache_manager(tmp_path),
+            multi_jenkins_manager=manager,
+        )
+
+        result = tool.execute(
+            job_name="team-a/inline-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            local_xml_path=str(xml_path),
+        )
+
+        assert result.success is True
+        assert "workspace directory" in result.data["error"]

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -37,7 +37,9 @@ def _make_jenkins_client(
     api_response: MagicMock = None,
 ) -> MagicMock:
     session = MagicMock()
-    session.get.return_value = api_response if api_response is not None else _make_response()
+    session.get.return_value = (
+        api_response if api_response is not None else _make_response()
+    )
 
     client = MagicMock()
     client.config = SimpleNamespace(url=base_url, timeout=timeout)
@@ -139,7 +141,10 @@ class TestGetJobDefinitionTool:
         assert result.success is True
         data = result.data
         assert data["definition_type"] == "scm_pipeline"
-        assert data["source_location"]["repo_url"] == "git@github.com:example/service-a.git"
+        assert (
+            data["source_location"]["repo_url"]
+            == "git@github.com:example/service-a.git"
+        )
         assert data["source_location"]["script_path"] == "ci/Jenkinsfile"
         assert data["local_xml_path"] is None
         assert "source control" in data["edit_instructions"]
@@ -155,7 +160,7 @@ class TestGetJobDefinitionTool:
             api_response=response,
             job_xml=(
                 "<flow-definition>"
-                "<definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\">"
+                '<definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition">'
                 "<script>pipeline { agent any; stages { stage('x') { steps { echo 'hello' } } } }</script>"
                 "</definition>"
                 "</flow-definition>"

--- a/tests/tools/test_jobs.py
+++ b/tests/tools/test_jobs.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``tools.jobs`` (find_jobs, get_job_definition, apply_job_xml_edit)."""
+"""Unit tests for ``tools.jobs`` (find_jobs, get_job_definition, apply_job_edit)."""
 
 from pathlib import Path
 from types import SimpleNamespace
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import requests
 
 from jenkins_mcp_enterprise.tools.jobs import (
-    ApplyJobXmlEditTool,
+    ApplyJobEditTool,
     FindJobsTool,
     GetJobDefinitionTool,
 )
@@ -35,15 +35,20 @@ def _make_jenkins_client(
     job_list=None,
     job_xml: str = "<xml />",
     api_response: MagicMock = None,
+    validation_payload=None,
 ) -> MagicMock:
     session = MagicMock()
     session.get.return_value = (
         api_response if api_response is not None else _make_response()
     )
+    raw_client = MagicMock()
+    raw_client.jenkins_request.return_value = _make_response(
+        json_payload=validation_payload
+    )
 
     client = MagicMock()
     client.config = SimpleNamespace(url=base_url, timeout=timeout)
-    client.connection = SimpleNamespace(session=session)
+    client.connection = SimpleNamespace(session=session, client=raw_client)
     client.list_jobs.return_value = job_list if job_list is not None else []
     client.get_job_config_xml.return_value = job_xml
     client.reconfig_job_xml.return_value = True
@@ -51,10 +56,10 @@ def _make_jenkins_client(
 
 
 def _make_manager(
-    xml_editing_enabled: bool = False, client: MagicMock = None
+    job_editing_enabled: bool = False, client: MagicMock = None
 ) -> MagicMock:
     manager = MagicMock()
-    manager.settings = {"enable_job_xml_editing": xml_editing_enabled}
+    manager.settings = {"enable_job_editing": job_editing_enabled}
     manager.get_usage_instructions.return_value = "configure instances"
     manager.resolve_jenkins_url.return_value = "prod"
     manager.get_jenkins_client.return_value = client
@@ -146,10 +151,12 @@ class TestGetJobDefinitionTool:
             == "git@github.com:example/service-a.git"
         )
         assert data["source_location"]["script_path"] == "ci/Jenkinsfile"
-        assert data["local_xml_path"] is None
+        assert data["local_edit_path"] is None
         assert "source control" in data["edit_instructions"]
 
-    def test_downloads_xml_for_inline_pipeline_when_editing_enabled(self, tmp_path):
+    def test_downloads_inline_script_for_inline_pipeline_when_editing_enabled(
+        self, tmp_path
+    ):
         response = _make_response(
             json_payload={
                 "_class": "org.jenkinsci.plugins.workflow.job.WorkflowJob",
@@ -166,7 +173,7 @@ class TestGetJobDefinitionTool:
                 "</flow-definition>"
             ),
         )
-        manager = _make_manager(xml_editing_enabled=True, client=client)
+        manager = _make_manager(job_editing_enabled=True, client=client)
         tool = GetJobDefinitionTool(
             jenkins_client=client,
             cache_manager=_make_cache_manager(tmp_path),
@@ -182,29 +189,76 @@ class TestGetJobDefinitionTool:
         assert result.success is True
         data = result.data
         assert data["definition_type"] == "inline_pipeline"
+        assert data["pipeline_style"] == "declarative"
         assert data["inline_script_truncated"] is True
-        assert data["local_xml_path"] is not None
-        xml_path = Path(data["local_xml_path"])
-        assert xml_path.exists()
+        assert data["edit_mode"] == "inline_pipeline_script"
+        assert data["local_edit_path"] is not None
+        script_path = Path(data["local_edit_path"])
+        assert script_path.exists()
         assert (
-            xml_path.read_text(encoding="utf-8")
-            == "<flow-definition><definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\"><script>pipeline { agent any; stages { stage('x') { steps { echo 'hello' } } } }</script></definition></flow-definition>"
+            script_path.read_text(encoding="utf-8")
+            == "pipeline { agent any; stages { stage('x') { steps { echo 'hello' } } } }"
         )
-        assert "apply_job_xml_edit" == data["edit_upload_tool"]
-        assert "downloaded locally" in data["edit_instructions"]
+        assert "apply_job_edit" == data["edit_upload_tool"]
+        assert "Groovy" in data["edit_instructions"]
 
 
-class TestApplyJobXmlEditTool:
+class TestApplyJobEditTool:
+    def test_uploads_local_inline_script_back_to_jenkins(self, tmp_path):
+        workspace_root = tmp_path / "job-definitions"
+        script_path = (
+            workspace_root / "prod" / "team-a" / "inline-pipeline" / "pipeline.groovy"
+        )
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text(
+            "pipeline { agent any; stages { stage('x') { steps { echo 'updated' } } } }",
+            encoding="utf-8",
+        )
+
+        client = _make_jenkins_client(
+            validation_payload={"status": "success", "message": ""}
+        )
+        client.get_job_config_xml.return_value = (
+            "<flow-definition>"
+            '<definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition">'
+            "<script>pipeline { agent any; stages { stage('x') { steps { echo 'original' } } } }</script>"
+            "</definition>"
+            "</flow-definition>"
+        )
+        manager = _make_manager(job_editing_enabled=True, client=client)
+        manager.settings["job_edit_workspace_dir"] = str(workspace_root)
+        tool = ApplyJobEditTool(
+            jenkins_client=client,
+            cache_manager=_make_cache_manager(tmp_path),
+            multi_jenkins_manager=manager,
+        )
+
+        result = tool.execute(
+            job_name="team-a/inline-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            local_edit_path=str(script_path),
+        )
+
+        assert result.success is True
+        assert result.data["edit_mode"] == "inline_pipeline_script"
+        assert result.data["updated"] is True
+        client.reconfig_job_xml.assert_called_once_with(
+            "team-a/inline-pipeline",
+            "<flow-definition><definition class=\"org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition\"><script>pipeline { agent any; stages { stage('x') { steps { echo 'updated' } } } }</script></definition></flow-definition>",
+        )
+
     def test_uploads_local_xml_back_to_jenkins(self, tmp_path):
         workspace_root = tmp_path / "job-definitions"
         xml_path = workspace_root / "prod" / "team-a" / "inline-pipeline" / "config.xml"
         xml_path.parent.mkdir(parents=True, exist_ok=True)
-        xml_path.write_text("<flow-definition updated='true' />", encoding="utf-8")
+        xml_path.write_text(
+            "<project><description>updated</description></project>", encoding="utf-8"
+        )
 
         client = _make_jenkins_client()
-        manager = _make_manager(xml_editing_enabled=True, client=client)
-        manager.settings["job_xml_workspace_dir"] = str(workspace_root)
-        tool = ApplyJobXmlEditTool(
+        manager = _make_manager(job_editing_enabled=True, client=client)
+        manager.settings["job_edit_workspace_dir"] = str(workspace_root)
+        tool = ApplyJobEditTool(
             jenkins_client=client,
             cache_manager=_make_cache_manager(tmp_path),
             multi_jenkins_manager=manager,
@@ -213,23 +267,71 @@ class TestApplyJobXmlEditTool:
         result = tool.execute(
             job_name="team-a/inline-pipeline",
             jenkins_url="https://jenkins.example.com",
-            local_xml_path=str(xml_path),
+            local_edit_path=str(xml_path),
         )
 
         assert result.success is True
+        assert result.data["edit_mode"] == "job_config_xml"
         assert result.data["updated"] is True
         client.reconfig_job_xml.assert_called_once_with(
-            "team-a/inline-pipeline", "<flow-definition updated='true' />"
+            "team-a/inline-pipeline",
+            "<project><description>updated</description></project>",
         )
 
-    def test_rejects_xml_path_outside_workspace(self, tmp_path):
+    def test_rejects_invalid_declarative_script_before_upload(self, tmp_path):
+        workspace_root = tmp_path / "job-definitions"
+        script_path = (
+            workspace_root / "prod" / "team-a" / "inline-pipeline" / "pipeline.groovy"
+        )
+        script_path.parent.mkdir(parents=True, exist_ok=True)
+        script_path.write_text(
+            "pipeline { agent any; stages { stage('broken') { steps { echo 'oops' } } }\n",
+            encoding="utf-8",
+        )
+
+        client = _make_jenkins_client(
+            validation_payload={
+                "status": "ok",
+                "data": {
+                    "result": "failure",
+                    "errors": [{"error": "expecting '}', found '' @ line 2"}],
+                },
+            }
+        )
+        client.get_job_config_xml.return_value = (
+            "<flow-definition>"
+            '<definition class="org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition">'
+            "<script>pipeline { agent any; stages { stage('x') { steps { echo 'original' } } } }</script>"
+            "</definition>"
+            "</flow-definition>"
+        )
+        manager = _make_manager(job_editing_enabled=True, client=client)
+        manager.settings["job_edit_workspace_dir"] = str(workspace_root)
+        tool = ApplyJobEditTool(
+            jenkins_client=client,
+            cache_manager=_make_cache_manager(tmp_path),
+            multi_jenkins_manager=manager,
+        )
+
+        result = tool.execute(
+            job_name="team-a/inline-pipeline",
+            jenkins_url="https://jenkins.example.com",
+            local_edit_path=str(script_path),
+        )
+
+        assert result.success is True
+        assert result.data["validation"]["valid"] is False
+        assert "rejected" in result.data["error"].lower()
+        client.reconfig_job_xml.assert_not_called()
+
+    def test_rejects_edit_path_outside_workspace(self, tmp_path):
         xml_path = tmp_path / "outside.xml"
         xml_path.write_text("<flow-definition />", encoding="utf-8")
 
         client = _make_jenkins_client()
-        manager = _make_manager(xml_editing_enabled=True, client=client)
-        manager.settings["job_xml_workspace_dir"] = str(tmp_path / "job-definitions")
-        tool = ApplyJobXmlEditTool(
+        manager = _make_manager(job_editing_enabled=True, client=client)
+        manager.settings["job_edit_workspace_dir"] = str(tmp_path / "job-definitions")
+        tool = ApplyJobEditTool(
             jenkins_client=client,
             cache_manager=_make_cache_manager(tmp_path),
             multi_jenkins_manager=manager,
@@ -238,7 +340,7 @@ class TestApplyJobXmlEditTool:
         result = tool.execute(
             job_name="team-a/inline-pipeline",
             jenkins_url="https://jenkins.example.com",
-            local_xml_path=str(xml_path),
+            local_edit_path=str(xml_path),
         )
 
         assert result.success is True


### PR DESCRIPTION
## Summary
- add job discovery and job definition tools, plus gated Jenkins XML edit/upload flow
- extend build listing for around-build windows and harden build triggering/session refresh behavior
- restore diagnosis/resource compatibility surfaces and clean up integration warnings

## Validation
- targeted unit/integration regression slices passed locally
- broader non-performance MCP integration suite passed locally
- Docker + local Jenkins verification completed for inline XML edit, SCM-backed definition lookup, and stale-crumb recovery after Jenkins restart